### PR TITLE
BAU: Improve documentation for thumbprint headers.

### DIFF
--- a/source/integrating-with-the-dcs.html.md.erb
+++ b/source/integrating-with-the-dcs.html.md.erb
@@ -13,7 +13,7 @@ To digitally check the validity of British passports as part of the Document Che
 
 It's up to you to decide which programming language your client is using. Your client must be able to [handle authentication][cryptography] against the DCS API.
 
-You must test your client in the dedicated test environment provided by the Government Digital Service (GDS). This environment contains test data to help you check that your application can handle all responses from the [DCS API][api-reference]. Once your client can handle all responses from the DCS API, you can connect to the DCS production environment.   
+You must test your client in the dedicated test environment provided by the Government Digital Service (GDS) before being granted access to the live environment. This environment contains test data to help you check that your application can handle all responses from the [DCS API][api-reference].
 
 ## Getting access to an environment
 

--- a/source/integrating-with-the-dcs.html.md.erb
+++ b/source/integrating-with-the-dcs.html.md.erb
@@ -19,7 +19,8 @@ You must test your client in the dedicated test environment provided by the Gove
 
 The test and production environments require dedicated [sets of keys and certificates][cryptography]. To connect to an environment, you must:
 
-* generate private keys and raise certificate signing requests for your encryption, signing, and TLS keys
+* generate private keys and raise certificate signing requests for your encryption, signing, and mutual authentication certificates.
+
 * receive the DCS's signing and encryption certificates
 
 Details about how to raise a certificate signing request with our Certificate Authority will follow after the expression of interest phase of the DCS pilot.

--- a/source/message-structure.html.md.erb
+++ b/source/message-structure.html.md.erb
@@ -35,7 +35,7 @@ Signatures in the JOSE message must use [RSASSA-PKCS1-V1_5] with the `SHA-256` h
 
 The [`alg` header in the JWS object][jws-alg-header] must be set to `RS256`.
 
-The [`x5t`][jws-x5t-header] and [`x5t#256`][jws-x5t256-header] must be set. The DCS uses these headers to confirm that the certificate used to sign the [JWS][JWE] object is allowed.
+You must set the [`x5t`][jws-x5t-header] and [`x5t#256`][jws-x5t256-header] headers. The DCS uses these headers to confirm that the certificate used to sign the [JWS][JWE] object is allowed.
 
 ## Encrypting messages
 
@@ -62,7 +62,7 @@ The [`alg` header in the JWE object][jwe-alg-header] must be set to `RSA-OAEP`.
 
 The [`enc` header in the JWE object][jwe-enc-header] must be set to `A128CBC-HS256`.
 
-The [`x5t`][jwe-x5t-header] and [`x5t#256`][jwe-x5t256-header] must be set. The DCS uses these headers to confirm that the certificate used to encrypt the [JWE][JWE] object is allowed.
+You must set the [`x5t`][jwe-x5t-header] and [`x5t#256`][jwe-x5t256-header] headers. The DCS uses these headers to confirm that the certificate used to encrypt the [JWE][JWE] object is allowed.
 
 ## Signature and encryption wrapper
 

--- a/source/message-structure.html.md.erb
+++ b/source/message-structure.html.md.erb
@@ -35,7 +35,7 @@ Signatures in the JOSE message must use [RSASSA-PKCS1-V1_5] with the `SHA-256` h
 
 The [`alg` header in the JWS object][jws-alg-header] must be set to `RS256`.
 
-The [`x5t`][jws-x5t-header] and [`x5t#256`][jws-x5t256-header] must be set according to the RFC. The DCS uses these headers to confirm that the certificate used to sign the [JWS][JWE] object is allowed.
+The [`x5t`][jws-x5t-header] and [`x5t#256`][jws-x5t256-header] must be set. The DCS uses these headers to confirm that the certificate used to sign the [JWS][JWE] object is allowed.
 
 ## Encrypting messages
 

--- a/source/message-structure.html.md.erb
+++ b/source/message-structure.html.md.erb
@@ -62,7 +62,7 @@ The [`alg` header in the JWE object][jwe-alg-header] must be set to `RSA-OAEP`.
 
 The [`enc` header in the JWE object][jwe-enc-header] must be set to `A128CBC-HS256`.
 
-The [`x5t`][jwe-x5t-header] and [`x5t#256`][jwe-x5t256-header] must be set according to the RFC. The DCS uses these headers to confirm that the certificate used to encrypt the [JWE][JWE] object is allowed.
+The [`x5t`][jwe-x5t-header] and [`x5t#256`][jwe-x5t256-header] must be set. The DCS uses these headers to confirm that the certificate used to encrypt the [JWE][JWE] object is allowed.
 
 ## Signature and encryption wrapper
 

--- a/source/message-structure.html.md.erb
+++ b/source/message-structure.html.md.erb
@@ -35,6 +35,8 @@ Signatures in the JOSE message must use [RSASSA-PKCS1-V1_5] with the `SHA-256` h
 
 The [`alg` header in the JWS object][jws-alg-header] must be set to `RS256`.
 
+The [`x5t`][jws-x5t-header] and [`x5t#256`][jws-x5t256-header] must be set according to the RFC. The DCS uses these headers to confirm that the certificate used to sign the [JWS][JWE] object is allowed.
+
 ## Encrypting messages
 
 Encryption provides the sender with assurance that only the intended receiver can see the message.
@@ -60,6 +62,8 @@ The [`alg` header in the JWE object][jwe-alg-header] must be set to `RSA-OAEP`.
 
 The [`enc` header in the JWE object][jwe-enc-header] must be set to `A128CBC-HS256`.
 
+The [`x5t`][jwe-x5t-header] and [`x5t#256`][jwe-x5t256-header] must be set according to the RFC. The DCS uses these headers to confirm that the certificate used to encrypt the [JWE][JWE] object is allowed.
+
 ## Signature and encryption wrapper
 
 The JSON object in request and response bodies is protected by a signature and encryption wrapper.
@@ -71,7 +75,5 @@ To build the [signature (JWS)][JWS] and [encryption (JWE)][JWE] wrapper for your
 3. Sign the encrypted content with your signing key using JWS.
 
 <%= image_tag "dcs-message-structure.svg" %>
-
-All JWS Headers must include the `x5t` header parameter. This is to allow the DCS to identify the correct certificate to use to check that the message was sent by a specific entity.
 
 <%= partial "partials/links" %>

--- a/source/message-structure.html.md.erb
+++ b/source/message-structure.html.md.erb
@@ -35,7 +35,7 @@ Signatures in the JOSE message must use [RSASSA-PKCS1-V1_5] with the `SHA-256` h
 
 The [`alg` header in the JWS object][jws-alg-header] must be set to `RS256`.
 
-You must set the [`x5t`][jws-x5t-header] and [`x5t#256`][jws-x5t256-header] headers. The DCS uses these headers to confirm that the certificate used to sign the JWS object is allowed.
+You must set the [`x5t`][jws-x5t-header] and [`x5t#256`][jws-x5t256-header] headers. The DCS uses these headers to confirm that the certificate used to sign the JWS object was signed by our Certificate Authority.
 
 ## Encrypting messages
 
@@ -62,7 +62,7 @@ The [`alg` header in the JWE object][jwe-alg-header] must be set to `RSA-OAEP`.
 
 The [`enc` header in the JWE object][jwe-enc-header] must be set to `A128CBC-HS256`.
 
-You must set the [`x5t`][jwe-x5t-header] and [`x5t#256`][jwe-x5t256-header] headers. The DCS uses these headers to confirm that the certificate used to encrypt the JWE object is allowed.
+You must set the [`x5t`][jwe-x5t-header] and [`x5t#256`][jwe-x5t256-header] headers. The DCS uses these headers to confirm that the certificate used to encrypt the JWE object was signed by our Certificate Authority.
 
 ## Signature and encryption wrapper
 

--- a/source/message-structure.html.md.erb
+++ b/source/message-structure.html.md.erb
@@ -35,7 +35,7 @@ Signatures in the JOSE message must use [RSASSA-PKCS1-V1_5] with the `SHA-256` h
 
 The [`alg` header in the JWS object][jws-alg-header] must be set to `RS256`.
 
-You must set the [`x5t`][jws-x5t-header] and [`x5t#256`][jws-x5t256-header] headers. The DCS uses these headers to confirm that the certificate used to sign the [JWS][JWE] object is allowed.
+You must set the [`x5t`][jws-x5t-header] and [`x5t#256`][jws-x5t256-header] headers. The DCS uses these headers to confirm that the certificate used to sign the JWS object is allowed.
 
 ## Encrypting messages
 
@@ -62,13 +62,13 @@ The [`alg` header in the JWE object][jwe-alg-header] must be set to `RSA-OAEP`.
 
 The [`enc` header in the JWE object][jwe-enc-header] must be set to `A128CBC-HS256`.
 
-You must set the [`x5t`][jwe-x5t-header] and [`x5t#256`][jwe-x5t256-header] headers. The DCS uses these headers to confirm that the certificate used to encrypt the [JWE][JWE] object is allowed.
+You must set the [`x5t`][jwe-x5t-header] and [`x5t#256`][jwe-x5t256-header] headers. The DCS uses these headers to confirm that the certificate used to encrypt the JWE object is allowed.
 
 ## Signature and encryption wrapper
 
 The JSON object in request and response bodies is protected by a signature and encryption wrapper.
 
-To build the [signature (JWS)][JWS] and [encryption (JWE)][JWE] wrapper for your JSON object, you must:
+To build the signature (JWS) and encryption (JWE) wrapper for your JSON object, you must:
 
 1. Sign your JSON object with your signing key using JWS.
 2. Encrypt your signed JSON object with your encryption key using JWE.

--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -44,9 +44,15 @@
 [date time format]: https://www.iso.org/iso-8601-date-and-time-format.html
 [github-issue]: https://github.com/alphagov/dcs-pilot-docs/issues/new?labels=bug
 [integrate]: /integrating-with-the-dcs/#integrating-with-the-dcs
+
 [jwe-alg-header]: https://www.rfc-editor.org/rfc/rfc7516.html#section-4.1.1
 [jwe-enc-header]: https://www.rfc-editor.org/rfc/rfc7516.html#section-4.1.2
 [jws-alg-header]: https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1.1
+[jws-x5t-header]: https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1.7
+[jws-x5t256-header]: https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1.8
+[jwe-x5t-header]: https://www.rfc-editor.org/rfc/rfc7516.html#section-4.1.9
+[jwe-x5t256-header]: https://www.rfc-editor.org/rfc/rfc7516.html#section-4.1.10
+
 [message-flow]: /message-flow/#message-flow
 [message-structure]: /message-structure/#message-structure
 [status-response-codes]: /status-response-codes


### PR DESCRIPTION
The `x5t` and `x5t#256` headers are optional in the RFC but mandatory for the DCS, as we use them to confirm that the certificate used to sign/encrypt is part of a safe-list on the DCS.