### PR TITLE
Remove Staticfile.auth

### DIFF
--- a/Staticfile.auth
+++ b/Staticfile.auth
@@ -1,1 +1,0 @@
-dcs-pilot:$apr1$hq6/BDZS$ZiG/NiOwKDGWqdu0XGtUO1


### PR DESCRIPTION
Once released, we don't want the docs to be behind username and 
password.