### PR TITLE
Add Code of conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ You should now be able to view a live preview at http://localhost:4567.
 ```
 Changes to the tech-docs.yml file require stopping and restarting the server to show up in the preview. You can stop it with Ctrl-C.
 
+## Code of conduct
+
+Please refer to the `alphagov` [code of conduct](https://github.com/alphagov/code-of-conduct).
 
 ## Licence
 


### PR DESCRIPTION
Add 'Code of conduct' section in README.
This section links to the `alphagov` Code of conduct.
This follows the pattern found in other `alphagov` repos.