### PR TITLE
Show last reviewed date for each page in the docs

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -48,3 +48,6 @@ github_repo: alphagov/dcs-pilot-docs # used to generate links in the contributio
 
 owner_slack_workspace: gds
 default_owner_slack: '#verify-dcs'
+
+# Setting show_expiry: false to not have a red banner at the bottom of the page when it's past the review due date. We'll only have the blue banner saying when the page was last reviewed. The expiry date (determined by the review_in parameter in the frontmatter) is for our internal regular review process.
+show_expiry: false

--- a/source/javascripts/application.js
+++ b/source/javascripts/application.js
@@ -1,4 +1,1 @@
 //= require govuk_tech_docs
-
-// Disable page expiry banner
-window.GOVUK.Modules.PageExpiry = null;


### PR DESCRIPTION
## What

Show the last [reviewed date](https://tdt-documentation.london.cloudapps.digital/page-expiry.html#page-expiry-and-review) for each page.

![image](https://user-images.githubusercontent.com/17963330/66767282-ee82a800-eea7-11e9-9089-8711d78a336f.png)

## Why

Doing this to increase users' confidence that they're seeing up-to-date content.