### PR TITLE
Update gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
     fast_blank (1.0.0)
     fastimage (2.1.7)
     ffi (1.11.1)
-    govuk_tech_docs (2.0.5)
+    govuk_tech_docs (2.0.7)
       activesupport
       chronic (~> 0.10.2)
       middleman (~> 4.0)
@@ -139,7 +139,7 @@ GEM
       rouge (~> 2.0)
     mini_portile2 (2.4.0)
     minitest (5.12.2)
-    multi_json (1.14.0)
+    multi_json (1.14.1)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     openapi3_parser (0.5.2)


### PR DESCRIPTION
## What

Includes updating `govuk_tech_docs` to [version 2.0.7](https://github.com/alphagov/tech-docs-gem/blob/master/CHANGELOG.md#207), which contains accessibility improvements.

## Why

So we can benefit from the latest features and fixes to the tech docs template ✨ 