### PR TITLE
Fix host configuration

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -1,6 +1,6 @@
 # Host to use for canonical URL generation (without trailing slash)
 # Hosting on PaaS on the default domain for now
-host: dcs-pilot-docs.cloudapps.digital
+host: https://dcs-pilot-docs.cloudapps.digital
 
 # Header-related options
 show_govuk_logo: false


### PR DESCRIPTION
## What 

Add missing `https://` to the host config in `config/tech-docs.yml`.

## Why

So proper URLs can be generated based on the configured host.

For example, not having the `https://` means Daniel the Manual Spaniel can't produce valid links:

![image](https://user-images.githubusercontent.com/17963330/67203715-ba593b00-f403-11e9-98f3-9868e2a175ae.png)

