### PR TITLE
BAU: Review `Message Structure` and update content flow

### DIFF
--- a/source/message-structure.html.md.erb
+++ b/source/message-structure.html.md.erb
@@ -15,7 +15,15 @@ Messages your client exchanges with the Document Checking Service (DCS) must be 
  - [JSON Web Signature (JWS)][JWS]
  - [JSON Web Encryption (JWE)][JWE]
 
-Our Certificate Authority will issue certificates for the [public key infrastructure (PKI)][RFC 6712]. Details about how to raise a certificate signing request with our Certificate Authority will follow after the expression of interest stage of the DCS pilot.
+The JSON object in request and response bodies is protected by a signature and encryption wrapper.
+
+To build the signature (JWS) and encryption (JWE) wrapper for your JSON object, you must:
+
+1. Sign your JSON object with your signing key using JWS.
+2. Encrypt your signed JSON object with your encryption key using JWE.
+3. Sign the encrypted content with your signing key using JWS.
+
+<%= image_tag "dcs-message-structure.svg" %>
 
 ## Signing messages
 
@@ -65,17 +73,5 @@ The [`alg` header in the JWE object][jwe-alg-header] must be set to `RSA-OAEP`.
 The [`enc` header in the JWE object][jwe-enc-header] must be set to `A128CBC-HS256`.
 
 You must set the [`x5t`][jwe-x5t-header] and [`x5t#256`][jwe-x5t256-header] headers. The DCS uses these headers to confirm that the certificate used to encrypt the JWE object was signed by our Certificate Authority.
-
-## Signature and encryption wrapper
-
-The JSON object in request and response bodies is protected by a signature and encryption wrapper.
-
-To build the signature (JWS) and encryption (JWE) wrapper for your JSON object, you must:
-
-1. Sign your JSON object with your signing key using JWS.
-2. Encrypt your signed JSON object with your encryption key using JWE.
-3. Sign the encrypted content with your signing key using JWS.
-
-<%= image_tag "dcs-message-structure.svg" %>
 
 <%= partial "partials/links" %>

--- a/source/message-structure.html.md.erb
+++ b/source/message-structure.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Message structure
 weight: 4
-last_reviewed_on: 2019-10-04
+last_reviewed_on: 2019-10-25
 review_in: 3 weeks
 ---
 

--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -61,4 +61,4 @@
 [message-structure]: /message-structure/#message-structure
 [mutual-auth]: /message-flow/#mutual-authentication
 [status-response-codes]: /status-response-codes
-[wrapper]: /message-structure/#signature-and-encryption-wrapper
+[wrapper]: /message-structure/#message-structure


### PR DESCRIPTION
* We were informed by 🐶 that `Message Structure` needs reviewing
* Taking stock of the writing workshop, we have moved the structure of the message itself to the top of the page as it's the focus of the content. It was previously at the bottom. 