### PR TITLE
Fix alt tags and settings

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -14,6 +14,7 @@ after_build do |builder|
       { :assume_extension => true,
         :disable_external => true,
         :allow_hash_href => true,
+        :empty_alt_ignore => true,
         :url_swap => { config[:tech_docs][:host] => "" } }).run
   rescue RuntimeError => e
     abort e.to_s

--- a/source/message-flow.html.md.erb
+++ b/source/message-flow.html.md.erb
@@ -9,7 +9,7 @@ review_in: 6 weeks
 
 The Document Checking Service (DCS) acts as an interface between your service and HM Passport Office.
 
-<%= image_tag "dcs-overview.svg" %>
+<%= image_tag "dcs-overview.svg", { :alt => '' } %>
 
 1. Your service sends a [passport check][check-passport] request to the DCS.
 2. The DCS validates the request and sends it to HM Passport Office.

--- a/source/message-structure.html.md.erb
+++ b/source/message-structure.html.md.erb
@@ -23,7 +23,7 @@ To build the signature (JWS) and encryption (JWE) wrapper for your JSON object, 
 2. Encrypt your signed JSON object with your encryption key using JWE.
 3. Sign the encrypted content with your signing key using JWS.
 
-<%= image_tag "dcs-message-structure.svg" %>
+<%= image_tag "dcs-message-structure.svg", { :alt => '' } %>
 
 ## Signing messages
 


### PR DESCRIPTION
## Why

Middleman defaults to introducing automatic `alt` tags based on the file name. This is not meaningful alt text.

When writing documentation, we always try to have the information in the image also present in the surrounding text. If this is not possible, then we write meaningful `alt` text.

However, in most cases, images in documentation are described in surrounding text so most of the time we need empty `alt` tags.

Relevant W3C guidance: https://www.w3.org/WAI/tutorials/images/decorative/

## What

* remove the linter check that looks for the existence of `alt` text
* add empty `alt` tags for all the images in these docs that are described in the surrounding text

## How to review

Check that:

* all the images with empty `alt` tags in these docs are described in surrounding text
* `alt` tags are indeed empty in the HTML
