### PR TITLE
BAU: Fix incorrect wording

### DIFF
--- a/source/message-structure.html.md.erb
+++ b/source/message-structure.html.md.erb
@@ -20,7 +20,7 @@ The JSON object in request and response bodies is protected by a signature and e
 To build the signature (JWS) and encryption (JWE) wrapper for your JSON object, you must:
 
 1. Sign your JSON object with your signing key using JWS.
-2. Encrypt your signed JSON object with your encryption key using JWE.
+2. Encrypt your signed JSON object with the DCS's public encryption certificate using JWE.
 3. Sign the encrypted content with your signing key using JWS.
 
 <%= image_tag "dcs-message-structure-sequence.svg", { :alt => '' } %>


### PR DESCRIPTION
## Why

I recognised that we had incorrectly documented how the a payload is structured.
Previously, the pilot docs suggested that a client using DCS would use their private encryption key to encrypt their payload.
This is incorrect, as it would mean that the DCS would be unable to decrypt the payload.
## What

The correct structure of a payload would be:

- signed object using private signing key
- encrypted payload using DCS's public encryption certificate
- signed content with private signing key

