### PR TITLE
Rate limit

### DIFF
--- a/source/status-response-codes.html.md.erb
+++ b/source/status-response-codes.html.md.erb
@@ -14,6 +14,7 @@ The Document Checking Service (DCS) uses standard [HTTP response code][HTTP-Stat
 | 200                | The DCS handled your request successfully. |
 | 404                | The DCS URI is incorrect.              |
 | 429                | You have exceeded your allocated number of API calls.  |
+| 503                | The DCS is temporarily unavailable because of high traffic. |
 | 5xx                | There is an internal server error. |
 
 Note that the `HTTP 200` response code means the DCS handled your request successfully. It does not confirm whether the passport is valid or not. Likewise, an `HTTP 200` does not necessarily mean that the DCS is operational.

--- a/source/status-response-codes.html.md.erb
+++ b/source/status-response-codes.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Status response codes
 weight: 6
-last_reviewed_on: 2019-12-27
+last_reviewed_on: 2020-02-04
 review_in: 6 weeks
 ---
 

--- a/source/status-response-codes.html.md.erb
+++ b/source/status-response-codes.html.md.erb
@@ -13,7 +13,7 @@ The Document Checking Service (DCS) uses standard [HTTP response code][HTTP-Stat
 | ------------------ | -------------------------------------- |
 | 200                | The DCS handled your request successfully. |
 | 404                | The DCS URI is incorrect.              |
-| 429                | You have exceeded your allocated number of API calls.  |
+| 429                | You have exceeded your total allocated number of API calls or your rate limit.  |
 | 503                | The DCS is temporarily unavailable because of high traffic. |
 | 5xx                | There is an internal server error. |
 

--- a/source/status-response-codes.html.md.erb
+++ b/source/status-response-codes.html.md.erb
@@ -14,7 +14,6 @@ The Document Checking Service (DCS) uses standard [HTTP response code][HTTP-Stat
 | 200                | The DCS handled your request successfully. |
 | 404                | The DCS URI is incorrect.              |
 | 429                | You have exceeded your allocated number of API calls.  |
-| 503                | HM Passport Office is having a planned outage. |
 | 5xx                | There is an internal server error. |
 
 Note that the `HTTP 200` response code means the DCS handled your request successfully. It does not confirm whether the passport is valid or not. Likewise, an `HTTP 200` does not necessarily mean that the DCS is operational.


### PR DESCRIPTION
## Why

DCS returns different HTTP response codes to those currently described in the pilot docs. 

This is partly because of our rate limiting work and partly because of removing 'planned outage' responses for HMPO's system.

## What

Updated the status codes documentation to be clear that you now get:

+ 503 when the collective rate limit for all pilot clients is exceeded
+ 429 when you've exceeded your individual client rate limit, as well as when you've exceeded your quota

## How to review

Please fact check that these are indeed the responses we send.
