### PR TITLE
Add section on rate limits

### DIFF
--- a/source/api-reference.html.md.erb
+++ b/source/api-reference.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: API reference
 weight: 6
-last_reviewed_on: 2020-02-04
+last_reviewed_on: 2020-02-07
 review_in: 3 weeks
 ---
 

--- a/source/api-reference.html.md.erb
+++ b/source/api-reference.html.md.erb
@@ -209,12 +209,13 @@ A list of strings which describes the error. This field is present if there was 
   
 ## Rate limits
 
-DCS will handle up to 50 requests in total every 10 seconds. 
+DCS handles up to 50 requests in total every 10 seconds. 
   
-Each organisation which connects to DCS for the pilot will be given a share of this rate limit. 
+This rate limit is divided fairly between the organisations connected to DCS for the pilot. 
   
-You'll get a 503 (Service unavailable) HTTP status code if, at the time you submitted your request, the combined traffic from all organisations connected to the DCS pilot exceeds the rate limit.
-
-You'll get a 429 (Too many requests) HTTP status code if you have gone over your individual share of the limit.
+DCS returns a:
+  
++ 503 (Service unavailable) HTTP status code if, at the time you submit a request, the combined total traffic from all pilot organisations is over the rate limit
++ 429 (Too many requests) HTTP status code if you have gone over your individual share of the limit
 
 <%= partial "partials/links" %>

--- a/source/api-reference.html.md.erb
+++ b/source/api-reference.html.md.erb
@@ -206,5 +206,15 @@ Boolean indicating if the passport is valid or not. This field is not included i
 
 #### errorMessage
 A list of strings which describes the error. This field is present if there was an error processing the request.
+  
+## Rate limits
+
+DCS will handle up to 50 requests in total every 10 seconds. 
+  
+Each organisation which connects to DCS for the pilot will be given a share of this rate limit. 
+  
+You'll get a 503 (Service unavailable) HTTP status code if, at the time you submitted your request, the combined traffic from all organisations connected to the DCS pilot exceeds the rate limit.
+
+You'll get a 429 (Too many requests) HTTP status code if you have gone over your individual share of the limit.
 
 <%= partial "partials/links" %>


### PR DESCRIPTION
## Why

Pilot participants should be aware there is a rate limit for DCS and what the limit is.

## What

Adds a short section to the API reference page describing the rate limit and the HTTP status codes users receive in the event it is exceeded.

