### PR TITLE
BAU: remove unnecessary headers

### DIFF
--- a/source/message-structure.html.md.erb
+++ b/source/message-structure.html.md.erb
@@ -72,6 +72,4 @@ The [`alg` header in the JWE object][jwe-alg-header] must be set to `RSA-OAEP`.
 
 The [`enc` header in the JWE object][jwe-enc-header] must be set to `A128CBC-HS256`.
 
-You must set the [`x5t`][jwe-x5t-header] and [`x5t#256`][jwe-x5t256-header] headers. The DCS uses these headers to confirm that the certificate used to encrypt the JWE object was signed by our Certificate Authority.
-
 <%= partial "partials/links" %>


### PR DESCRIPTION

## Why

Remove duplicated header paragraph

## What

These headers are needed for the signing layers, but are not needed for encryption. Remove this paragraph to reduce confusion. The header is still documented in the signing section above.

