### PR TITLE
Deploy test site for user research

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,18 @@ language: ruby
 cache: bundler
 script: bundle exec middleman build
 deploy:
-  provider: cloudfoundry
-  api: https://api.cloud.service.gov.uk
-  username: tech-doc-tool@digital.cabinet-office.gov.uk
-  password:
-    secure: YdOlNet68nBzCYX047eNh7hvgr4dsI87GnpliVi6EYJg3laCR31fi2d7iPTJ+E2FYwypgJUzdqoVhPNIQWc8OvAQ4nn7QefcDf3+5+i7ASRdsnhXwTq2Pb6wJGO01de/Ai4M39jlo7XEDdPyKXwYYd2tgQ6LpjPudZ3RTnX3JAV1z4GCB/Gb9eeoKvs6eGibJBynq/NAhAtFCn0Wy3+SAJjjJ5qJPzxOeY2TXtE7AmCFTihRPfssQofKCSo+AXBbm+eJndyg0If3nD4zAhehlG3oi/TOUbNALlZgiQdamdYRY8wGd2KaVkrNo21NtM7/KDOZiOCYC/T7Rz1ktov+iWD8qUtQJmDWYXbkNtj5OkboChmnU8RrY4R+O5t2zpIEGA4nmWCEKAUuPd8XlwjKVjTXQlVMGlIN5niZpfV7/Ou7b8OLqJMQkcMABAMifYv5K48ihb3RI6X+yhH+jc2kQcrijtkN2bT4C0rPDYxkUt0bkwZS6lzRbtR7bB7shVz99VZyQwbU6p5sjCw3JwEyb4HH2nMDWS6eu8w5xMCHQi58/x20RyKeaUnOENbadqInuKxGriCFrQjoRB+YhCjj7D3V2mRxyBrhqaGN15YhT3CdJgOZS49Hr4OBOc/I0U4G/OKwhvzSN2xke2DE9Rx66HSjQba4ZsPOT/ZQZpyKuQE=
-  organization: govuk-verify
-  space: docs
-  on:
-    repo: alphagov/dcs-pilot-docs
+  - on:
+      repo: alphagov/dcs-pilot-docs
+      branch: master
+    <<: &deploy
+      provider: cloudfoundry
+      api: https://api.cloud.service.gov.uk
+      username: tech-doc-tool@digital.cabinet-office.gov.uk
+      password:
+        secure: YdOlNet68nBzCYX047eNh7hvgr4dsI87GnpliVi6EYJg3laCR31fi2d7iPTJ+E2FYwypgJUzdqoVhPNIQWc8OvAQ4nn7QefcDf3+5+i7ASRdsnhXwTq2Pb6wJGO01de/Ai4M39jlo7XEDdPyKXwYYd2tgQ6LpjPudZ3RTnX3JAV1z4GCB/Gb9eeoKvs6eGibJBynq/NAhAtFCn0Wy3+SAJjjJ5qJPzxOeY2TXtE7AmCFTihRPfssQofKCSo+AXBbm+eJndyg0If3nD4zAhehlG3oi/TOUbNALlZgiQdamdYRY8wGd2KaVkrNo21NtM7/KDOZiOCYC/T7Rz1ktov+iWD8qUtQJmDWYXbkNtj5OkboChmnU8RrY4R+O5t2zpIEGA4nmWCEKAUuPd8XlwjKVjTXQlVMGlIN5niZpfV7/Ou7b8OLqJMQkcMABAMifYv5K48ihb3RI6X+yhH+jc2kQcrijtkN2bT4C0rPDYxkUt0bkwZS6lzRbtR7bB7shVz99VZyQwbU6p5sjCw3JwEyb4HH2nMDWS6eu8w5xMCHQi58/x20RyKeaUnOENbadqInuKxGriCFrQjoRB+YhCjj7D3V2mRxyBrhqaGN15YhT3CdJgOZS49Hr4OBOc/I0U4G/OKwhvzSN2xke2DE9Rx66HSjQba4ZsPOT/ZQZpyKuQE=
+      organization: govuk-verify
+      space: docs
+  - on:
+      repo: alphagov/dcs-pilot-docs
+      branch: test
+    <<: *deploy

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ This is the documentation for the [Document Checking Sytem (DCS) pilot](https://
 
 The pages are hosted at https://dcs-pilot-docs.cloudapps.digital on the [GOV.UK PaaS](https://www.cloud.service.gov.uk/)
 
-
 # Getting Started
 
 To see the version of Ruby used by the application, see [the ruby-version file](.ruby-version).
@@ -21,12 +20,12 @@ This will allow you to compile Ruby, and makes it easier to manage multiple Ruby
 
 Download the current version of Ruby that the [application uses](.ruby-version):
 ```
-rbenv install 2.6.5 # substitute <2.6.5> with version found in .ruby-version
+rbenv install $(cat .ruby-version)
 ```
 
-Set your Ruby version to match what `rbenv` installed in the previous step:
+Set your local Ruby version to match what `rbenv` installed in the previous step:
 ```
-rbenv local 2.6.5 # substitute with version installed. change local to global, if wanted.
+rbenv local $(cat .ruby-version)
 ```
 
 Install the application's dependencies:
@@ -34,7 +33,6 @@ Install the application's dependencies:
 ```
 bundle install
 ```
-
 
 ## Making changes
 To make changes, edit the markdown files in the source folder.
@@ -57,7 +55,7 @@ In order to configure some aspects of layout, like the header, edit `config/tech
 
 The repository uses [Travis CI](https://travis-ci.com/alphagov/dcs-pilot-docs/) to run a basic pre-commit. This ensures that changes do not break the application.
 
-Before commiting any changes, the contributor should run this command in the application directory:
+Before committing any changes, the contributor should run this command in the application directory:
 
 ```
 bundle exec middleman build
@@ -85,6 +83,12 @@ If all goes well, something like the following output will be displayed:
 You should now be able to view a live preview at http://localhost:4567.
 ```
 Changes to the tech-docs.yml file require stopping and restarting the server to show up in the preview. You can stop it with Ctrl-C.
+
+### Prototyping
+
+The 'test' branch is used for producing prototypes of the documentation for user testing. It is hosted at https://test:test@dcs-pilot-docs-test.cloudapps.digital.
+
+The DCS for user testing is different to the DCS used in production. Do not use this prototype documentation to connect to DCS unless instructed by the DCS team.
 
 ## Code of conduct
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 ---
 applications:
-- name: dcs-pilot-docs
+- name: dcs-pilot-docs-test
   memory: 64M
   instances: 2

--- a/source/Staticfile.auth
+++ b/source/Staticfile.auth
@@ -1,0 +1,1 @@
+test:{SHA}qUqP5cyxm6YcTAhz05Hph5gvu9M=


### PR DESCRIPTION
## Why

This follows on from #111, which set things up on master to enable us to create a test version of the site on the 'test' branch. We'll use this for prototyping things for user research before feeding them into the live version of the docs.

There's a simple username/password (test/test) to reduce the risk of people confusing the test site with the live site.

## What
Pull in changes from master. Change config to new URL/PaaS app and [credentials](https://tdt-documentation.london.cloudapps.digital/publish_project/deploy/#add-basic-authentication).

