### PR TITLE
BAU: add support for `RSA-OAEP-256` encryption

### DIFF
--- a/source/message-structure.html.md.erb
+++ b/source/message-structure.html.md.erb
@@ -68,7 +68,7 @@ The encrypted component of the JOSE message must use:
  * [RSAES-OAEP] as the algorithm, detailed in the [JSON Web Algorithms specification][JWA]
  * [A128CBC-HS256] as the encryption method, detailed in the [JSON Web Algorithms specification][JWA].
 
-The [`alg` header in the JWE object][jwe-alg-header] must be set to `RSA-OAEP`.
+The [`alg` header in the JWE object][jwe-alg-header] must be set to `RSA-OAEP` or `RSA-OAEP-256`.
 
 The [`enc` header in the JWE object][jwe-enc-header] must be set to `A128CBC-HS256`.
 


### PR DESCRIPTION
This is the same as `RSA-OAEP`, except it uses SHA256 instead of SHA1. Both algorithms are still secure - despite SHA1 being now considered weak, it is [only used as an entropy source](https://eprint.iacr.org/2006/223.pdf), so doesn't need to be collision-resistant.

It is still good to officially document support for both, though. Some libraries mark `RSA-OAEP` as deprecated, but support for `RSA-OAEP-256` is not yet ubiquitous. The DCS already supports both, so there's no extra work for us to do.

In the long term, we might want to consider switching from RSA-based algorithms to elliptic-curve-based algorithms. This is because [RSA is generally considered harder to implement correctly](https://blog.trailofbits.com/2019/07/08/fuck-rsa/). However, we're not going to do that now, since it would require substantial changes to the DCS and our certificate processes that we have not yet the time for.
