### PR TITLE
Remove "Integrating..." section and put all overview content on the homepage

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,22 +1,41 @@
 ---
 title: Document Checking Service pilot
 weight: 1
-last_reviewed_on: 2020-02-24
+last_reviewed_on: 2020-02-28
 review_in: 6 weeks
 ---
 
 # Document Checking Service pilot
 
-This technical documentation is for organisations taking part in the [Document Checking Service (DCS) pilot][govuk-link]. The pilot will allow organisations to digitally check the validity of British passports.
+This technical documentation is for organisations taking part in the Document Checking Service (DCS) pilot. 
 
-Use this documentation to find out:
+You can use the DCS to check digitally whether a given British passport is valid or not.
 
-* [how the DCS works][message-flow]
-* what is involved in [integrating with the DCS API][connect]
-* how to [structure requests for the DCS API][message-structure]
-* [what you can do with the DCS API][api-reference]
+GDS will onboard selected pilot participants during a ‘connecting window’ starting in early 2020. 
 
-We will onboard selected pilot participants during a 'connecting window' starting from the beginning of 2020.
-We will be refining the onboarding process as we go, and participants should therefore be aware that the process may change between iterations.
+## Integrating with the DCS API
+
+To integrate your service with the DCS API you will need to:
+
+1. Develop a client to integrate with the DCS API.
+1. Test your client in a dedicated DCS test environment.
+1. Run your client in the production environment as part of the DCS pilot.
+
+It's up to you to decide which programming language your client uses.
+
+This documentation explains [how the DCS works] and provides step by step guidance on how to:
+
++ generate keys and request certificates for your DCS connection
++ set up a mutual TLS connection to DCS
++ sign and encrypt a DCS payload
++ handle responses from the DCS 
+
+## Getting access to production
+
+You'll need to successfully complete a full journey in the test environment before you can get access to the production environment.
+
+You'll need a different set of keys and certificates for your production connection.
+
+Contact the [DCS pilot helpdesk](/support) if you're ready to request access to production.
 
 <%= partial "partials/links" %>

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -11,7 +11,7 @@ This technical documentation is for organisations taking part in the Document Ch
 
 You can use the DCS to check digitally whether a given UK passport is valid or not.
 
-GDS will onboard selected pilot participants during a ‘connecting window’ starting in early 2020. 
+GDS will onboard selected pilot participants during a ‘connecting window’ starting in spring 2020. 
 
 ## Integrating with the DCS API
 
@@ -23,12 +23,12 @@ To integrate your service with the DCS API you will need to:
 
 It's up to you to decide which programming language your client uses.
 
-This documentation explains [how the DCS works] and provides step by step guidance on how to:
+This documentation explains [how the DCS works][how-dcs-works] and provides step by step guidance on how to:
 
-+ generate keys and request certificates for your DCS connection
-+ set up a mutual TLS connection to DCS
++ [generate keys and request certificates for your DCS connection][keys-and-certificates]
++ [set up a mutual TLS connection to DCS][mutual-tls-to-dcs]
 + sign and encrypt a DCS payload
-+ handle responses from the DCS 
++ [handle responses from the DCS][handle-dcs-responses]
 
 ## Getting access to production
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -9,7 +9,7 @@ review_in: 6 weeks
 
 This technical documentation is for organisations taking part in the Document Checking Service (DCS) pilot. 
 
-You can use the DCS to check digitally whether a given British passport is valid or not.
+You can use the DCS to check digitally whether a given UK passport is valid or not.
 
 GDS will onboard selected pilot participants during a ‘connecting window’ starting in early 2020. 
 

--- a/source/integrating-with-the-dcs.html.md.erb
+++ b/source/integrating-with-the-dcs.html.md.erb
@@ -2,6 +2,7 @@
 title: Integrating with the Document Checking Service
 weight: 3
 last_reviewed_on: 2020-02-28
+review_in: 6 weeks
 ---
 
 # Integrating with the Document Checking Service
@@ -16,7 +17,7 @@ It's up to you to decide which programming language your client is using. Your c
 
 You must test your client in the dedicated test environment provided by the Government Digital Service (GDS) before getting access to the production environment. This environment contains test data to help you check that your application can handle all responses from the [DCS API][api-reference]. Once your client can handle all responses from the DCS API, you can connect to the DCS production environment.
 
-## Prerequisites
+## Pre-requisites
 
 Before you start to build a client there are several things you need.
 

--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -43,13 +43,11 @@
 [github-issue]: https://github.com/alphagov/dcs-pilot-docs/issues/new?labels=bug
 [govuk-link]: https://www.gov.uk/guidance/apply-for-the-document-checking-service-pilot-scheme
 [how-dcs-works]: /how-dcs-works/#how-the-dcs-works
-
 [integrate]: /integrating-with-the-dcs/#integrating-with-the-dcs
 [passport-check-request-payload-schema]: /code/dcs-passport-check-request-payload.json-schema.json
 
 [json-schema]: https://json-schema.org/
 [json-schema-validators]: https://json-schema.org/implementations.html#validators
-
 [jwe-alg-header]: https://www.rfc-editor.org/rfc/rfc7516.html#section-4.1.1
 [jwe-enc-header]: https://www.rfc-editor.org/rfc/rfc7516.html#section-4.1.2
 [jws-alg-header]: https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1.1

--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -37,7 +37,6 @@
 [check-passport-response]: /api-reference/#response
 [check-passport]: /api-reference/#check-passport-validity
 [check-status]: /api-reference/#check-the-dcs-status
-[connect]: /integrating-with-the-dcs/#integrating-with-the-document-checking-service
 [date time format]: https://www.iso.org/iso-8601-date-and-time-format.html
 [dcs-pilot-support@digital.cabinet-office.gov.uk]: mailto:dcs-pilot-support@digital.cabinet-office.gov.uk
 [EASS]: https://www.equalityadvisoryservice.com/

--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -42,6 +42,7 @@
 [EASS]: https://www.equalityadvisoryservice.com/
 [github-issue]: https://github.com/alphagov/dcs-pilot-docs/issues/new?labels=bug
 [govuk-link]: https://www.gov.uk/guidance/apply-for-the-document-checking-service-pilot-scheme
+[handle-dcs-responses][/handling-responses/#handling-responses-from-the-dcs]
 [how-dcs-works]: /how-dcs-works/#how-the-dcs-works
 [integrate]: /integrating-with-the-dcs/#integrating-with-the-dcs
 [passport-check-request-payload-schema]: /code/dcs-passport-check-request-payload.json-schema.json
@@ -56,7 +57,9 @@
 [jwe-x5t-header]: https://www.rfc-editor.org/rfc/rfc7516.html#section-4.1.9
 [jwe-x5t256-header]: https://www.rfc-editor.org/rfc/rfc7516.html#section-4.1.10
 
+[keys-and-certificates]: (/generating-keys-and-csrs/#generate-keys-and-request-certificates)
 [message-flow]: /how-dcs-works/#message-flow
 [message-structure]: /how-dcs-works/#signing-and-encryption
 [mutual-auth]: /how-dcs-works/#mutual-authentication
+[mutual-tls-to-dcs]: /set-up-mtls-to-dcs/#set-up-a-mutual-tls-connection-to-the-dcs
 [wrapper]: /how-dcs-works/#signing-and-encryption

--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -42,7 +42,7 @@
 [EASS]: https://www.equalityadvisoryservice.com/
 [github-issue]: https://github.com/alphagov/dcs-pilot-docs/issues/new?labels=bug
 [govuk-link]: https://www.gov.uk/guidance/apply-for-the-document-checking-service-pilot-scheme
-[handle-dcs-responses][/handling-responses/#handling-responses-from-the-dcs]
+[handle-dcs-responses]: /handling-responses/#handling-responses-from-the-dcs
 [how-dcs-works]: /how-dcs-works/#how-the-dcs-works
 [integrate]: /integrating-with-the-dcs/#integrating-with-the-dcs
 [passport-check-request-payload-schema]: /code/dcs-passport-check-request-payload.json-schema.json
@@ -57,7 +57,7 @@
 [jwe-x5t-header]: https://www.rfc-editor.org/rfc/rfc7516.html#section-4.1.9
 [jwe-x5t256-header]: https://www.rfc-editor.org/rfc/rfc7516.html#section-4.1.10
 
-[keys-and-certificates]: (/generating-keys-and-csrs/#generate-keys-and-request-certificates)
+[keys-and-certificates]: /generating-keys-and-csrs/#generate-keys-and-request-certificates
 [message-flow]: /how-dcs-works/#message-flow
 [message-structure]: /how-dcs-works/#signing-and-encryption
 [mutual-auth]: /how-dcs-works/#mutual-authentication


### PR DESCRIPTION
## Why

The "Integrating with DCS" guide provided some high-level information about the process you'd follow to connect up to DCS for the pilot. Most of that is covered in more detail with the new guides we've written since the lab day.

## What

+ deletes the "Integrating with DCS" guide 
+ retains some of the content in simplified form and moves it to the homepage
+ remove some content from the homepage and simplify what's left

## How to review

I don't think I've deleted something crucial, but might be worth a quick check.

I think I'll need help with some merge conflicts too...
