### PR TITLE
lK5rICbK - Update usage of DCS signing certificate

### DIFF
--- a/source/integrating-with-the-dcs.html.md.erb
+++ b/source/integrating-with-the-dcs.html.md.erb
@@ -57,7 +57,7 @@ These certificates will be provided to you when your pilot application has been 
 
 | No. |   Purpose   |     Type    |    Origin    |           Usage               |
 |-----|-------------|-------------|--------------|-------------------------------|
-|  1  | Signing     | Certificate | DCS supplies | Used to validate DCS request signatures |
+|  1  | Signing     | Certificate | DCS supplies | Used to validate DCS response signatures |
 |  2  | Encryption  | Certificate | DCS supplies | Used to encrypt your request payloads   |
 |  3  | mTLS        | CA Bundle   | DCS supplies | Chain of trust for your mTLS configuration |
 


### PR DESCRIPTION
## Why

DCS signing certificate is used by the client to validate DCS response signatures.

## What

Update usage of DCS signing certificate

