### PR TITLE
Finesse the 'prerequisites' guide

### DIFF
--- a/source/integrating-with-the-dcs.html.md.erb
+++ b/source/integrating-with-the-dcs.html.md.erb
@@ -5,18 +5,6 @@ last_reviewed_on: 2020-02-28
 review_in: 6 weeks
 ---
 
-# Integrating with the Document Checking Service
-
-To digitally check the validity of British passports as part of the [Document Checking Service (DCS) pilot][govuk-link], you must integrate with the DCS API. There are several steps you must complete to integrate with the DCS API:
-
-1. Develop a client to integrate with the DCS API.
-1. Test your client in a dedicated DCS test environment.
-1. Run your client in the production environment as part of the DCS pilot.
-
-It's up to you to decide which programming language your client is using. Your client must be able to [handle authentication][mutual-auth] against the DCS API.
-
-You must test your client in the dedicated test environment provided by the Government Digital Service (GDS) before getting access to the production environment. This environment contains test data to help you check that your application can handle all responses from the [DCS API][api-reference]. Once your client can handle all responses from the DCS API, you can connect to the DCS production environment.
-
 ## Pre-requisites
 
 Before you start to build a client there are several things you need.

--- a/source/integrating-with-the-dcs.html.md.erb
+++ b/source/integrating-with-the-dcs.html.md.erb
@@ -1,24 +1,27 @@
 ---
-title: Integrating with the Document Checking Service
+title: Preparing to build a client
 weight: 3
 last_reviewed_on: 2020-02-28
 review_in: 6 weeks
 ---
 
-## Pre-requisites
+# Preparing to build a client
 
 Before you start to build a client there are several things you need.
 
-### DCS URI
+## DCS URI
+
 There is one URI for the production environment, and one URI for the integration environment. These will be provided when your pilot application is approved.
 
-### Access to DCS Certificate Authority portals
+## Access to DCS Certificate Authority portals
+
 You will be provided URIs to access to our Certificate Authority portals in order to submit a Certificate Signing Request.
 There is one portal for each environment you need to raise Certificate Signing Request (CSR) with.
 
 Each DCS environment has its own Certificate Authority portal where you can submit your CSR.
 
-### Certificates and Keys
+## Certificates and Keys
+
 There are two sets of certificates and keys that you need to call the DCS:
 
 There are two environments that you will need to integrate with:
@@ -30,7 +33,7 @@ Each environment requires their own keys and certificates.
 
 You can read about [how to generate keys and request certificates][keys-and-certificates] in this documentation.
 
-#### Your certificates and keys
+### Your certificates and keys
 
 | No. |   Purpose   |     Type    |    Origin    |           Usage               |
 |-----|-------------|-------------|--------------|-------------------------------|
@@ -41,7 +44,7 @@ You can read about [how to generate keys and request certificates][keys-and-cert
 |  5  | mTLS        | Private Key | You generate |     Your mTLS configuration   |
 |  6  | mTLS        | Certificate | You generate CSR from private key and submit to CA portal | Your mTLS configuration
 
-#### DCS certificates
+### DCS certificates
 
 These certificates will be provided to you when your pilot application has been approved:
 

--- a/source/integrating-with-the-dcs.html.md.erb
+++ b/source/integrating-with-the-dcs.html.md.erb
@@ -40,6 +40,8 @@ There are two environments that you will need to integrate with:
 
 Each environment requires their own keys and certificates.
 
+You can read about [how to generate keys and request certificates][keys-and-certificates] in this documentation.
+
 #### Your certificates and keys
 
 | No. |   Purpose   |     Type    |    Origin    |           Usage               |
@@ -60,20 +62,6 @@ These certificates will be provided to you when your pilot application has been 
 |  1  | Signing     | Certificate | DCS supplies | Used to validate DCS response signatures |
 |  2  | Encryption  | Certificate | DCS supplies | Used to encrypt your request payloads   |
 |  3  | mTLS        | CA Bundle   | DCS supplies | Chain of trust for your mTLS configuration |
-
-
-## How to request your public certificates
-
-The DCS requires your public certificates to be signed by our CA.
-
-To get your certificates, you need to:
-
-1. create a private key
-2. create a CSR from your private key
-3. navigate to the relevant Certificate Authority portal (integration or production)
-4. submit the CSR
-
-You will be provided with your public certificates via email when the CSR has been signed by our Certificate Authority.
 
 
 <%= partial "partials/links" %>


### PR DESCRIPTION
## Why

Some content is duplicated in the step by step certificates guide we now have, and on the homepage. (My previous PR to delete it had some merge conflict funny business).

## What

Deletes the 'integrating to DCS' content that's now on the homepage
Removes CSR guidance from the prerequisites and replaces it with a link to the step by step guide
Renames the guide, since it's no longer about 'integrating' as such