### PR TITLE
Tell users they need to use a JW* library

### DIFF
--- a/source/Set-up-your-JOSE-certificate-thumbprints.html.md.erb
+++ b/source/Set-up-your-JOSE-certificate-thumbprints.html.md.erb
@@ -11,9 +11,9 @@ You’ll need to include a certificate ‘thumbprint’ (also sometimes known as
 
 The thumbprint is a hash of the public certificate used to sign or encrypt the JWS or JWE object. DCS uses the thumbprint to look up which certificate to use to validate your signature or decrypt your message.
 
-The [library you use to build JWS and JWE objects](/sign-and-encrypt-a-DCS-payload/#choose-a-library-to-use-for-jws-and-jwe) may be able to create thumbprints for you. If you need to create the thumbprints yourself, follow this guide.
+The [library you use to build JWS and JWE objects](/sign-and-encrypt-a-DCS-payload/#choose-a-library-to-use-for-jws-and-jwe) may be able to create thumbprints for you.
 
-To manually set up your certificate thumbprints, you’ll need to:
+If you need to create the thumbprints manually yourself, you’ll need to:
 
 1. Check your certificate is in binary DER format.
 1. Hash the binary representation of the certificate.

--- a/source/Set-up-your-JOSE-certificate-thumbprints.html.md.erb
+++ b/source/Set-up-your-JOSE-certificate-thumbprints.html.md.erb
@@ -11,7 +11,9 @@ You’ll need to include a certificate ‘thumbprint’ (also sometimes known as
 
 The thumbprint is a hash of the public certificate used to sign or encrypt the JWS or JWE object. DCS uses the thumbprint to look up which certificate to use to validate your signature or decrypt your message.
 
-To set up your certificate thumbprints, you’ll need to:
+The [library you use to build JWS and JWE objects](/sign-and-encrypt-a-DCS-payload/#choose-a-library-to-use-for-jws-and-jwe) may be able to create thumbprints for you. If you need to create the thumbprints yourself, follow this guide.
+
+To manually set up your certificate thumbprints, you’ll need to:
 
 1. Check your certificate is in binary DER format.
 1. Hash the binary representation of the certificate.

--- a/source/sign-and-encrypt-a-DCS-payload.html.md.erb
+++ b/source/sign-and-encrypt-a-DCS-payload.html.md.erb
@@ -9,6 +9,7 @@ review_in: 6 weeks
 
 To build the JSON Web Signature (JWS) and JSON Web Encryption (JWE) wrapper for your JSON object, you must:
 
+1. Choose a library to use for JWS and JWE.
 1. Build a plain JSON payload.
 1. Create JWS headers.
 1. Sign your JSON payload to get a JWS object.
@@ -18,6 +19,10 @@ To build the JSON Web Signature (JWS) and JSON Web Encryption (JWE) wrapper for 
 <%= image_tag "dcs-message-structure-sequence.svg", { :alt => '' } %>
 
 The diagram shows the steps you must take to build the signing and encryption wrapper for your JSON object. It shows you start with a plain JSON object. You then sign this object to get a JWS object. You then encrypt this JWS object to get a JWE object. Finally, the diagram shows you sign your JWE object. This will give you a final payload which has been signed, encrypted, and signed again.
+
+## Choose a library to use for JWS and JWE
+
+Use a well-maintained library for your language to help you build JWS and JWE objects.
 
 ## Build a plain JSON payload
 
@@ -61,7 +66,7 @@ Depending on the library you use, you might have to manually construct the JWS h
 ```
 ## Sign your JSON payload to get a JWS object
 
-You need to sign your JSON payload using a JWS library. To configure your signing of the JWS object in your chosen library, you should use:
+To sign your JSON payload, you'll need to configure your chosen JWS library. You need to use:
 
 * the JWS headers you created
 * the DCS’s client signing key


### PR DESCRIPTION
We'd referenced "your library" a few times without explicitly saying you need to use one. This should avoid some confusion.

This PR adds a short section to the 'sign and encrypt' guide to tell users they need to pick a library. We should come back another time with some recommendations for common languages.

It also adds a note to the 'thumbprints' guide to say you don't need to generate them if your library will do it for you, which might save some users some time.