### PR TITLE
66OPHmaD: document new Retry-After header

### DIFF
--- a/source/api-reference.html.md.erb
+++ b/source/api-reference.html.md.erb
@@ -214,4 +214,6 @@ DCS returns a:
 + 503 (Service unavailable) HTTP status code if, at the time you submit a request, the combined total traffic from all pilot organisations is over the rate limit
 + 429 (Too many requests) HTTP status code if you have gone over your individual share of the limit
 
+In both cases, the [`Retry-After`][Retry-After] HTTP header specifies how many seconds you should wait before retrying.
+
 <%= partial "partials/links" %>

--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -15,6 +15,7 @@
 [JWS]: https://www.rfc-editor.org/info/rfc7515
 [PKCS1]: https://www.rfc-editor.org/info/rfc2437
 [REST]: https://restfulapi.net/
+[Retry-After]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
 [RFC 2437]: https://www.rfc-editor.org/info/rfc2437
 [RFC 2616]: https://www.rfc-editor.org/info/rfc2616
 [RFC 3447]: https://www.rfc-editor.org/info/rfc3447

--- a/source/status-response-codes.html.md.erb
+++ b/source/status-response-codes.html.md.erb
@@ -13,8 +13,8 @@ The Document Checking Service (DCS) uses standard [HTTP response code][HTTP-Stat
 | ------------------ | -------------------------------------- |
 | 200                | The DCS handled your request successfully. |
 | 404                | The DCS URI is incorrect.              |
-| 429                | You have exceeded your total allocated number of API calls or your rate limit.  |
-| 503                | The DCS is temporarily unavailable because of high traffic. |
+| 429                | You have exceeded your total allocated number of API calls or your rate limit. <p>The [`Retry-After`][Retry-After] HTTP header specifies how many seconds you should wait before retrying.</p> |
+| 503                | The DCS is temporarily unavailable because of high traffic. <p>The [`Retry-After`][Retry-After] HTTP header specifies how many seconds you should wait before retrying.</p> |
 | 5xx                | There is an internal server error. |
 
 Note that the `HTTP 200` response code means the DCS handled your request successfully. It does not confirm whether the passport is valid or not. Likewise, an `HTTP 200` does not necessarily mean that the DCS is operational.


### PR DESCRIPTION
## Why

We provide this header when a user hits a rate limit to help them know how long to wait before trying again.

## What

Document the use of the `Retry-After` header.
