### PR TITLE
Remove mutual auth paragraph from intro

### DIFF
--- a/source/integrating-with-the-dcs.html.md.erb
+++ b/source/integrating-with-the-dcs.html.md.erb
@@ -30,10 +30,6 @@ This documentation shows you how to integrate with the DCS.
 1. [Sign and encrypt a DCS payload](/sign-and-encrypt-a-DCS-payload/#sign-and-encrypt-a-dcs-payload).
 1. [Access the data in a DCS response](/access-the-data-in-a-DCS-response/#access-the-data-in-a-dcs-response).
 
-### Using mutual authentication to connect
-
-When connecting to the DCS, you’ll use mutual authentication to secure the messages your client exchanges with the DCS. You’ll use client certificates over Transport Layer Security (TLS) Protocol Version 1.2.
-
 ## Getting access to production
 
 You’ll need to successfully complete a full journey in the test environment before you can get access to the production environment.


### PR DESCRIPTION
## Why

Just reading through, it seems odd that we call out mutual auth with its own paragraph - it's not the only thing you have to do to connect and nor is it the most difficult, so it reads oddly for it to be given this prominence.

I thought about writing a little bit of detail for each of the things in the list, but that doesn't seem to add much so I thought it was simpler to just remove this para.

## What

Deletes the 'Using mutual authentication to connect' paragraph from the 'How DCS works' section.

## How to review

@PippaClarkGDS what do you think?
