### PR TITLE
G7RK6f1q: document how quotas work

### DIFF
--- a/source/api-reference.html.md.erb
+++ b/source/api-reference.html.md.erb
@@ -220,7 +220,7 @@ In both cases, the [`Retry-After`][Retry-After] HTTP header specifies how many s
 
 Each organisation connected to the DCS for the pilot will have a quota of DCS checks. This is a fixed limit on the number of production DCS checks that the organisation can make during the pilot.
 
-The DCS returns a 403 (Forbidden) HTTP status code if you have used up your quota. You will be able to make no further DCS checks after this point.
+The DCS returns a 403 (Forbidden) HTTP status code if you have used up your quota. You won't be able to make any more DCS checks after this point.
 
 You can see your quota usage in HTTP headers in passport validity responses from the DCS.
 

--- a/source/api-reference.html.md.erb
+++ b/source/api-reference.html.md.erb
@@ -216,4 +216,17 @@ DCS returns a:
 
 In both cases, the [`Retry-After`][Retry-After] HTTP header specifies how many seconds you should wait before retrying.
 
+## Quotas
+
+Each organisation connected to the DCS for the pilot will have a quota of DCS checks. This is a fixed limit on the number of production DCS checks that the organisation can make during the pilot.
+
+The DCS returns a 403 (Forbidden) HTTP status code if you have used up your quota. You will be able to make no further DCS checks after this point.
+
+You can see your quota usage in HTTP headers in passport validity responses from the DCS.
+
+* `DCS-Quota-Limit` is the total number of checks you will be able to make as part of the DCS pilot
+* `DCS-Quota-Remaining` is the number of checks you have remaining
+
+These headers will be present in responses with 200 and 403 HTTP status codes. The DCS may also add these headers to other responses.
+
 <%= partial "partials/links" %>

--- a/source/api-reference.html.md.erb
+++ b/source/api-reference.html.md.erb
@@ -203,7 +203,7 @@ Boolean indicating if the passport is valid or not. This field is not included i
 #### errorMessage
 A list of strings which describes the error. This field is present if there was an error processing the request.
 
-## Rate limits
+## Understand rate limits in the DCS
 
 DCS handles up to 50 requests in total every 10 seconds.
 
@@ -216,17 +216,15 @@ DCS returns a:
 
 In both cases, the [`Retry-After`][Retry-After] HTTP header specifies how many seconds you should wait before retrying.
 
-## Quotas
+## Understand quotas in the DCS
 
-Each organisation connected to the DCS for the pilot will have a quota of DCS checks. This is a fixed limit on the number of production DCS checks that the organisation can make during the pilot.
+Each organisation connected to the DCS for the pilot will have a quota of checks for the DCS. This quota is a fixed limit on how many checks the organisation can make in DCS production during the pilot.
 
 The DCS returns a 403 (Forbidden) HTTP status code if you have used up your quota. You won't be able to make any more DCS checks after this point.
 
-You can see your quota usage in HTTP headers in passport validity responses from the DCS.
+You can see your quota usage in the HTTP headers when you receive passport validity responses from the DCS.
 
-* `DCS-Quota-Limit` is the total number of checks you will be able to make as part of the DCS pilot
+* `DCS-Quota-Limit` is the total number of checks you'll be able to make as part of the DCS pilot
 * `DCS-Quota-Remaining` is the number of checks you have remaining
-
-These headers will be present in responses with 200 and 403 HTTP status codes. The DCS may also add these headers to other responses.
 
 <%= partial "partials/links" %>

--- a/source/api-reference.html.md.erb
+++ b/source/api-reference.html.md.erb
@@ -220,7 +220,7 @@ In both cases, the [`Retry-After`][Retry-After] HTTP header specifies how many s
 
 Each organisation connected to the DCS for the pilot will have a quota of checks for the DCS. This quota is a fixed limit on how many checks the organisation can make in DCS production during the pilot.
 
-The DCS returns a 403 (Forbidden) HTTP status code if you have used up your quota. You won't be able to make any more DCS checks after this point.
+The DCS returns a 403 (Forbidden) HTTP status code if you have used up your quota. You will not be able to make DCS checks after this point.
 
 You can see your quota usage in the HTTP headers when you receive passport validity responses from the DCS.
 

--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -38,7 +38,7 @@
 [check-passport-response]: /api-reference/#check-passport-validity-response
 [check-passport]: /api-reference/#check-passport-validity
 [check-status]: /api-reference/#check-the-dcs-status
-[quotas]: /api-reference/#quotas
+[quotas]: /api-reference/#understand-quotas-in-the-dcs
 [connect]: /integrating-with-the-dcs/#integrating-with-the-document-checking-service
 [cryptography-encryption]: /message-structure/#encryption
 [cryptography-signing]: /message-structure/#signing

--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -38,6 +38,7 @@
 [check-passport-response]: /api-reference/#check-passport-validity-response
 [check-passport]: /api-reference/#check-passport-validity
 [check-status]: /api-reference/#check-the-dcs-status
+[quotas]: /api-reference/#quotas
 [connect]: /integrating-with-the-dcs/#integrating-with-the-document-checking-service
 [cryptography-encryption]: /message-structure/#encryption
 [cryptography-signing]: /message-structure/#signing

--- a/source/status-response-codes.html.md.erb
+++ b/source/status-response-codes.html.md.erb
@@ -12,6 +12,7 @@ The Document Checking Service (DCS) uses standard [HTTP response code][HTTP-Stat
 | HTTP response code | Description                            |
 | ------------------ | -------------------------------------- |
 | 200                | The DCS handled your request successfully. |
+| 403                | You have used up [your quota of DCS checks][quotas] and are no longer permitted to make DCS checks.
 | 404                | The DCS URI is incorrect.              |
 | 429                | You have exceeded your total allocated number of API calls or your rate limit. <p>The [`Retry-After`][Retry-After] HTTP header specifies how many seconds you should wait before retrying.</p> |
 | 503                | The DCS is temporarily unavailable because of high traffic. <p>The [`Retry-After`][Retry-After] HTTP header specifies how many seconds you should wait before retrying.</p> |

--- a/source/status-response-codes.html.md.erb
+++ b/source/status-response-codes.html.md.erb
@@ -12,7 +12,7 @@ The Document Checking Service (DCS) uses standard [HTTP response code][HTTP-Stat
 | HTTP response code | Description                            |
 | ------------------ | -------------------------------------- |
 | 200                | The DCS handled your request successfully. |
-| 403                | You have used up [your quota of DCS checks][quotas] and are no longer permitted to make DCS checks.
+| 403                | You have used up [your quota of DCS checks][quotas] and cannot make any more DCS checks.
 | 404                | The DCS URI is incorrect.              |
 | 429                | You have exceeded your total allocated number of API calls or your rate limit. <p>The [`Retry-After`][Retry-After] HTTP header specifies how many seconds you should wait before retrying.</p> |
 | 503                | The DCS is temporarily unavailable because of high traffic. <p>The [`Retry-After`][Retry-After] HTTP header specifies how many seconds you should wait before retrying.</p> |


### PR DESCRIPTION

## Why
Pilot clients have quotas that limit the total number of checks they can make. We need to document how this works and how clients can find out information on their usage.

Note that this only applies to pilot clients - our existing clients do not have quotas.
## What

Explain what quotas are and how they appear for pilot clients. Document the headers clients can use to monitor their usage.



