### PR TITLE
kvMZlCZz: document JOSE libraries we've tested

### DIFF
--- a/source/sign-and-encrypt-a-DCS-payload.html.md.erb
+++ b/source/sign-and-encrypt-a-DCS-payload.html.md.erb
@@ -29,6 +29,7 @@ The DCS team have tested that you can make successful DCS checks using these lib
 * C#: [jose-jwt](https://www.nuget.org/packages/jose-jwt/)
 * Go: [jose2go](https://github.com/dvsekhvalnov/jose2go)
 * Java: [Nimbus JOSE + JWT](https://connect2id.com/products/nimbus-jose-jwt)
+* node.js: [jose](https://www.npmjs.com/package/jose)
 * Python: [JWCrypto](https://jwcrypto.readthedocs.io/en/latest/)
 
 ## Build a plain JSON payload

--- a/source/sign-and-encrypt-a-DCS-payload.html.md.erb
+++ b/source/sign-and-encrypt-a-DCS-payload.html.md.erb
@@ -24,6 +24,11 @@ The diagram shows the steps you must take to build the signing and encryption wr
 
 Use a well-maintained library for your language to help you build JWS and JWE objects.
 
+The DCS team have tested that you can make successful DCS checks using these libraries:
+
+* Java: [Nimbus JOSE + JWT](https://connect2id.com/products/nimbus-jose-jwt)
+* Python: [JWCrypto](https://jwcrypto.readthedocs.io/en/latest/)
+
 ## Build a plain JSON payload
 
 Create a JSON object containing the details of the passport you want to check, for example:

--- a/source/sign-and-encrypt-a-DCS-payload.html.md.erb
+++ b/source/sign-and-encrypt-a-DCS-payload.html.md.erb
@@ -26,6 +26,7 @@ Use a well-maintained library for your language to help you build JWS and JWE ob
 
 The DCS team have tested that you can make successful DCS checks using these libraries:
 
+* C#: [jose-jwt](https://www.nuget.org/packages/jose-jwt/)
 * Java: [Nimbus JOSE + JWT](https://connect2id.com/products/nimbus-jose-jwt)
 * Python: [JWCrypto](https://jwcrypto.readthedocs.io/en/latest/)
 

--- a/source/sign-and-encrypt-a-DCS-payload.html.md.erb
+++ b/source/sign-and-encrypt-a-DCS-payload.html.md.erb
@@ -27,6 +27,7 @@ Use a well-maintained library for your language to help you build JWS and JWE ob
 The DCS team have tested that you can make successful DCS checks using these libraries:
 
 * C#: [jose-jwt](https://www.nuget.org/packages/jose-jwt/)
+* Go: [jose2go](https://github.com/dvsekhvalnov/jose2go)
 * Java: [Nimbus JOSE + JWT](https://connect2id.com/products/nimbus-jose-jwt)
 * Python: [JWCrypto](https://jwcrypto.readthedocs.io/en/latest/)
 

--- a/source/sign-and-encrypt-a-DCS-payload.html.md.erb
+++ b/source/sign-and-encrypt-a-DCS-payload.html.md.erb
@@ -26,9 +26,9 @@ Use a well-maintained library for your language to help you build JWS and JWE ob
 
 The DCS team have tested that you can make successful DCS checks using these libraries:
 
-* C#: [jose-jwt](https://www.nuget.org/packages/jose-jwt/)
 * Go: [jose2go](https://github.com/dvsekhvalnov/jose2go)
 * Java: [Nimbus JOSE + JWT](https://connect2id.com/products/nimbus-jose-jwt)
+* .NET: [jose-jwt](https://www.nuget.org/packages/jose-jwt/)
 * node.js: [jose](https://www.npmjs.com/package/jose)
 * Python: [JWCrypto](https://jwcrypto.readthedocs.io/en/latest/)
 


### PR DESCRIPTION
## Why

From our user research, we've seen that users appreciate knowing which JOSE libraries are known to work with the DCS.

Be careful with the working to make it clear that we've tested that they work. Do not recommend using any particular library as we have not done enough in-depth investigation of them to check that they are suitable (e.g. secure, well-maintained, licensing).

## What

Document the libraries with which I am certain that we have made successful DCS checks.

I've tested the clients written in Python and Java, so know that they work against the DCS. For the other languages, I've consulted with the people who wrote clients using those languages - see the individual commits for details.

Note that we had a number of user research participants attempt to use Ruby to connect to the DCS. However, they all ran out of time before making a successful check. So we cannot confidently say that any particular Ruby libraries do/don't work with the DCS.