### PR TITLE
52O7YkqU: document new rate-limit headers

### DIFF
--- a/source/api-reference.html.md.erb
+++ b/source/api-reference.html.md.erb
@@ -211,15 +211,17 @@ This rate limit is divided fairly between the organisations connected to DCS for
 
 ### Tracking your rate limit usage
 
-The DCS provides information about your rate limit usage in HTTP response headers. This follows the draft ['RateLimit Header Fields for HTTP' RFC](https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html).
+The DCS provides information about your rate limit usage in HTTP response headers.
+
+The DCS's HTTP response headers contain information such as:
 
 * [`X-RateLimit-Limit`](https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html#rfc.section.3.1): the maximum number of requests you can make in the current time window
 * [`X-RateLimit-Remaining`](https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html#rfc.section.3.2): the remaining number of requests you can make in the current time window
 * [`X-RateLimit-Reset`](https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html#rfc.section.3.3): the time in seconds until the current usage resets
 
-### When you exceed the rate limit
+### Exceeding rate limits
 
-DCS returns a:
+When you exceed the rate limit, the DCS returns a:
 
 + 503 (Service unavailable) HTTP status code if, at the time you submit a request, the combined total traffic from all pilot organisations is over the rate limit
 + 429 (Too many requests) HTTP status code if you have gone over your individual share of the limit

--- a/source/api-reference.html.md.erb
+++ b/source/api-reference.html.md.erb
@@ -209,6 +209,16 @@ DCS handles up to 50 requests in total every 10 seconds.
 
 This rate limit is divided fairly between the organisations connected to DCS for the pilot.
 
+### Tracking your rate limit usage
+
+The DCS provides information about your rate limit usage in HTTP response headers. This follows the draft ['RateLimit Header Fields for HTTP' RFC](https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html).
+
+* [`X-RateLimit-Limit`](https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html#rfc.section.3.1): the maximum number of requests you can make in the current time window
+* [`X-RateLimit-Remaining`](https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html#rfc.section.3.2): the remaining number of requests you can make in the current time window
+* [`X-RateLimit-Reset`](https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html#rfc.section.3.3): the time in seconds until the current usage resets
+
+### When you exceed the rate limit
+
 DCS returns a:
 
 + 503 (Service unavailable) HTTP status code if, at the time you submit a request, the combined total traffic from all pilot organisations is over the rate limit


### PR DESCRIPTION


## Why

We added these headers to help clients understand how they were using their rate limit. Document what clients should look for.

## What

Document the new rate limit headers. Split the rate limit section with some new h3s.
