### PR TITLE
BR9gNJHs: Add information about generating request-specific data in the payload

### DIFF
--- a/source/api-reference.html.md.erb
+++ b/source/api-reference.html.md.erb
@@ -100,8 +100,8 @@ For example, below is the structure of the JSON object in a request body without
 
 ```json
 {
-  "correlationId": "550e8400-e29b-41d4-a716-446655440000",
-  "requestId": "550e8400-e29b-41d4-a716-446655440003",
+  "correlationId": "a16c296f-4f03-4f25-af32-91240b1e0da7",
+  "requestId": "5d700930-c41b-4e99-92cd-e9517dce11c8",
   "timestamp": "1997-07-16T19:20:30.45+01:00",
   "passportNumber": "123456789",
   "surname": "Smith",

--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -1,6 +1,6 @@
 [HTTP-Status-Code]: https://www.rfc-editor.org/rfc/rfc2616.html#section-10
 [HTTP]: https://www.rfc-editor.org/info/rfc2616
-[ISO 1601]: https://www.iso.org/iso-8601-date-and-time-format.html
+[ISO 8601]: https://www.iso.org/iso-8601-date-and-time-format.html
 [JavaScript Object Notation]: https://www.rfc-editor.org/info/rfc8259
 [JavaScript Object Signing and Encryption]: https://jose.readthedocs.io/en/latest
 [JOSE]: https://jose.readthedocs.io/en/latest

--- a/source/sign-and-encrypt-a-DCS-payload.html.md.erb
+++ b/source/sign-and-encrypt-a-DCS-payload.html.md.erb
@@ -59,7 +59,7 @@ You must generate the following fields in your application:
 
 Most programming languages support generating RFC 4122-compliant universally unique identifiers (UUIDs), and ISO 8601-compliant timestamps.
 
-We recommend using [version 4 UUIDs](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)) as they are based on random input.
+We recommend using [version 4 UUIDs](https://tools.ietf.org/html/rfc4122#section-4.4) as they are based on random input.
 
 ## Create JWS headers
 

--- a/source/sign-and-encrypt-a-DCS-payload.html.md.erb
+++ b/source/sign-and-encrypt-a-DCS-payload.html.md.erb
@@ -38,8 +38,8 @@ Create a JSON object containing the details of the passport you want to check, f
 
 ```json
 {
-  "correlationId": "550e8400-e29b-41d4-a716-446655440000",
-  "requestId": "550e8400-e29b-41d4-a716-446655440003",
+  "correlationId": "21206c34-4d97-47c4-8aee-6fb0d80b311b",
+  "requestId": "e1651f51-5db8-4e8c-9cf7-68fd4063404e",
   "timestamp": "1997-07-16T19:20:30.45+01:00",
   "passportNumber": "123456789",
   "surname": "Smith",

--- a/source/sign-and-encrypt-a-DCS-payload.html.md.erb
+++ b/source/sign-and-encrypt-a-DCS-payload.html.md.erb
@@ -54,7 +54,7 @@ Create a JSON object containing the details of the passport you want to check, f
 
 You must generate `correlationId`, `requestId`, and `timestamp` in your own application.
 
-Most programming languages support generating [RFC 4122] compliant UUIDs and [ISO 8601] compliant timestamps.
+Most programming languages support generating RFC 4122-compliant universally unique identifiers (UUIDs), and ISO 8601-compliant timestamps.
 
 We recommend using [version 4 UUIDs](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)) as they are based on random input.
 

--- a/source/sign-and-encrypt-a-DCS-payload.html.md.erb
+++ b/source/sign-and-encrypt-a-DCS-payload.html.md.erb
@@ -52,7 +52,10 @@ Create a JSON object containing the details of the passport you want to check, f
 }
 ```
 
-You must generate `correlationId`, `requestId`, and `timestamp` in your own application.
+You must generate the following fields in your application:
+- `correlationId`
+- `requestId`
+- `timestamp`
 
 Most programming languages support generating RFC 4122-compliant universally unique identifiers (UUIDs), and ISO 8601-compliant timestamps.
 

--- a/source/sign-and-encrypt-a-DCS-payload.html.md.erb
+++ b/source/sign-and-encrypt-a-DCS-payload.html.md.erb
@@ -51,6 +51,13 @@ Create a JSON object containing the details of the passport you want to check, f
   "expiryDate": "2020-01-01"
 }
 ```
+
+You must generate `correlationId`, `requestId`, and `timestamp` in your own application.
+
+Most programming languages support generating [RFC 4122] compliant UUIDs and [ISO 8601] compliant timestamps.
+
+We recommend using [version 4 UUIDs](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)) as they are based on random input.
+
 ## Create JWS headers
 
 The JWS headers contain information about how you have signed the payload, along with certificate thumbprints which allow the DCS to look up which certificate you’re using.


### PR DESCRIPTION
## Why

Make it clear that correlationId, requestId, and timestamp need to be generated by clients within their application.

## What

* Add very minor information - almost all programming languages support generating uuids and timestamps in the correct format.
* Fix minor error in _link.erb where the ISO is mis-numbered

## How to review

`./preview-with-docker.sh` and navigate to `http://localhost:4567/sign-and-encrypt-a-DCS-payload/#build-a-plain-json-payload`