### PR TITLE
BAU: use correct header name

### DIFF
--- a/source/sign-and-encrypt-a-DCS-payload.html.md.erb
+++ b/source/sign-and-encrypt-a-DCS-payload.html.md.erb
@@ -99,7 +99,7 @@ You must set the following headers:
 
 * `enc` must be set to `A128CBC-HS256`
 * `alg` must be set to `RSA-OAEP`
-* `type` must be set to `JWE`
+* `typ` must be set to `JWE`
 * `x5t` contains the SHA1 thumbprint of the DCS encryption certificate
 * `x5t#S256` contains the SHA256 thumbprint of the DCS encryption certificate
 


### PR DESCRIPTION
It's 'typ', not 'type' - see https://tools.ietf.org/html/rfc7516#section-4.1.11
