### PR TITLE
BAU: update guidance on algorithms

### DIFF
--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -58,6 +58,7 @@
 [jws-x5t256-header]: https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1.8
 [jwe-x5t-header]: https://www.rfc-editor.org/rfc/rfc7516.html#section-4.1.9
 [jwe-x5t256-header]: https://www.rfc-editor.org/rfc/rfc7516.html#section-4.1.10
+[supported-JWE-encodings]: https://www.rfc-editor.org/rfc/rfc7518.html#section-5.1
 
 [message-flow]: /message-flow/#message-flow
 [message-structure]: /message-structure/#message-structure

--- a/source/sign-and-encrypt-a-DCS-payload.html.md.erb
+++ b/source/sign-and-encrypt-a-DCS-payload.html.md.erb
@@ -97,7 +97,7 @@ The JWE headers contain information about how the payload is encrypted.
 
 You must set the following headers:
 
-* `enc` must be set to `A128CBC-HS256` or any other [value permitted by RFC 7518](https://tools.ietf.org/html/rfc7518#section-5.1)
+* `enc` must be set to `A128CBC-HS256` or any other [value permitted by RFC 7518][supported-JWE-encodings]
 * `alg` must be set to `RSA-OAEP-256`
 * `typ` must be set to `JWE`
 * `x5t` contains the SHA1 thumbprint of the DCS encryption certificate
@@ -121,9 +121,9 @@ Your header should look like this:
 The encrypted component of the JSON Object Signing and Encryption (JOSE) message must use:
 
 * `RSA-OAEP-256` as the algorithm
-* any encryption method [permitted by RFC 7518](https://tools.ietf.org/html/rfc7518#section-5.1), e.g. `A128CBC-HS256`
+* any encryption method [permitted by RFC 7518][supported-JWE-encodings], e.g. `A128CBC-HS256`
 
-You can [learn more about these in the JSON Web Algorithms specification](https://tools.ietf.org/html/rfc7518).
+You can [learn more about these in the JSON Web Algorithms specification][RFC 7518].
 
 ## Sign your JWE object to complete the process
 

--- a/source/sign-and-encrypt-a-DCS-payload.html.md.erb
+++ b/source/sign-and-encrypt-a-DCS-payload.html.md.erb
@@ -97,7 +97,7 @@ The JWE headers contain information about how the payload is encrypted.
 
 You must set the following headers:
 
-* `enc` must be set to `A128CBC-HS256` or any other [value permitted by RFC 7518][supported-JWE-encodings]
+* `enc` must be set to a value [permitted by RFC 7518][supported-JWE-encodings], for example `A128CBC-HS256`
 * `alg` must be set to `RSA-OAEP-256`
 * `typ` must be set to `JWE`
 * `x5t` contains the SHA1 thumbprint of the DCS encryption certificate
@@ -121,7 +121,7 @@ Your header should look like this:
 The encrypted component of the JSON Object Signing and Encryption (JOSE) message must use:
 
 * `RSA-OAEP-256` as the algorithm
-* any encryption method [permitted by RFC 7518][supported-JWE-encodings], e.g. `A128CBC-HS256`
+* any encryption method [permitted by RFC 7518][supported-JWE-encodings], for example `A128CBC-HS256`
 
 You can [learn more about these in the JSON Web Algorithms specification][RFC 7518].
 

--- a/source/sign-and-encrypt-a-DCS-payload.html.md.erb
+++ b/source/sign-and-encrypt-a-DCS-payload.html.md.erb
@@ -68,8 +68,8 @@ The JWS headers contain information about how you have signed the payload, along
 For the DCS, you need to set the following headers:
 
 1. `x5t` contains the SHA1 thumbprint of your certificate.
-1. `x5t#S256` containing the SHA256 thumbprint of your certificate.
-1. `alg` must be set to `RS256`.
+1. `x5t#S256` contains the SHA256 thumbprint of your certificate.
+1. `alg` must be set to one of: `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, or `PS512`.
 
 You must set the `x5t` and `x5t#S256` headers. To set them, you’ll need to have [generated thumbprints for your signing certificate](/Set-up-your-JOSE-certificate-thumbprints).
 
@@ -97,8 +97,8 @@ The JWE headers contain information about how the payload is encrypted.
 
 You must set the following headers:
 
-* `enc` must be set to `A128CBC-HS256`
-* `alg` must be set to `RSA-OAEP`
+* `enc` must be set to `A128CBC-HS256` or any other [value permitted by RFC 7518](https://tools.ietf.org/html/rfc7518#section-5.1)
+* `alg` must be set to `RSA-OAEP-256`
 * `typ` must be set to `JWE`
 * `x5t` contains the SHA1 thumbprint of the DCS encryption certificate
 * `x5t#S256` contains the SHA256 thumbprint of the DCS encryption certificate
@@ -110,7 +110,7 @@ Your header should look like this:
 ```json
 {
   "enc":"A128CBC-HS256",
-  "alg":"RSA-OAEP",
+  "alg":"RSA-OAEP-256",
   "typ":"JWE",
   "x5t":"xiWgxFMOIw1M4m9LYCnKZk5eHJs",
   "x5t#S256":"PJLEl_B6MFKaMEG6HK7BBdaueJc7e-SiimQfvEpTYj4"
@@ -118,12 +118,12 @@ Your header should look like this:
 ```
 ### Using encryption algorithms
 
-The encrypted component of the JavaScript Object Signing and Encryption (JOSE) message must use:
+The encrypted component of the JSON Object Signing and Encryption (JOSE) message must use:
 
-* `RSA-OAEP` as the algorithm
-* `A128CBC-HS256` as the encryption method
+* `RSA-OAEP-256` as the algorithm
+* any encryption method [permitted by RFC 7518](https://tools.ietf.org/html/rfc7518#section-5.1), e.g. `A128CBC-HS256`
 
-You can [learn more about these in the JSON Web Algorithms specification](https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40).
+You can [learn more about these in the JSON Web Algorithms specification](https://tools.ietf.org/html/rfc7518).
 
 ## Sign your JWE object to complete the process
 
@@ -133,4 +133,4 @@ After creating your JWE object, you need to use JWS to sign your payload for a s
 
 In your library, you should use the same JWS tools and headers you created when you first signed your JSON payload.
 
- <%= partial "partials/links" %>
+<%= partial "partials/links" %>


### PR DESCRIPTION

## Why

Be more permissive where possible to make life easier for new clients.

Stop recommending an encryption algorithm that is considered deprecated.

## What

* Be more permissive in the JWS alg header and the JWE enc header. The permissable alternatives are all supported by the DCS and are at least as secure as the one we originally recommended.
* Change the JWE alg header to mandate the more secure version of the header. `RSA-OAEP` is still valid, but it uses SHA-1, so is widely considered deprecated. We should therefore discourage new clients from using it.
* Update a link to a draft RFC to the final approved RFC.
* As per RFC 7518, JOSE stands for 'JSON Object Signing and Encryption'. Update accordingly.
