### PR TITLE
BAU: Status (GET) requests do not need `Content-Type: application/jose`

### DIFF
--- a/source/api-reference.html.md.erb
+++ b/source/api-reference.html.md.erb
@@ -30,8 +30,6 @@ The DCS integration endpoint is <https://dcs-integration.ida.digital.cabinet-off
 
 `GET: /checks/passport`
 
-The HTTP header must contain `Content-Type: application/jose`.
-
 The request body for a DCS status check is empty and therefore does not require the [signature and encryption wrapper](/sign-and-encrypt-a-DCS-payload/#sign-and-encrypt-a-dcs-payload).
 
 ### Response


### PR DESCRIPTION
There is no request body, and the response is plain JSON.