### PR TITLE
H3WCW3iA: provide more detail on rate limits

### DIFF
--- a/source/api-reference.html.md.erb
+++ b/source/api-reference.html.md.erb
@@ -210,7 +210,7 @@ As a pilot participant, you will be subject to the following rate limits. Both u
 1. An overall rate limit of 50 requests every 10 seconds. This is shared between all pilot participants.
 1. An individual rate limit of (300 / number of participants) requests every 60 seconds. For instance, if 10 participants join the pilot, you would have an individual rate limit of 30 requests every 60 seconds.
 
-We may change these rate limits in future to better meet your needs.
+These rate limits may change over the course of the pilot.
 
 ### Tracking your rate limit usage
 

--- a/source/api-reference.html.md.erb
+++ b/source/api-reference.html.md.erb
@@ -203,12 +203,10 @@ A list of strings which describes the error. This field is present if there was 
 
 ## Understand rate limits in the DCS
 
-The DCS can handle up to 50 requests in total every 10 seconds.
+As a pilot participant, you'll be subject to both:
 
-As a pilot participant, you will be subject to the following rate limits. Both use a sliding window rate limit algorithm.
-
-1. An overall rate limit of 50 requests every 10 seconds. This is shared between all pilot participants.
-1. An individual rate limit of (300 / number of participants) requests every 60 seconds. For instance, if 10 participants join the pilot, you would have an individual rate limit of 30 requests every 60 seconds.
+* an overall rate limit of 50 requests in any 10 second period - this is shared between all pilot participants
+* an individual rate limit of (300 / number of participants) requests in any 60 second period - for example if 10 participants join the pilot, you would have an individual rate limit of 30 requests in any 60 second period
 
 These rate limits may change over the course of the pilot.
 

--- a/source/api-reference.html.md.erb
+++ b/source/api-reference.html.md.erb
@@ -203,9 +203,14 @@ A list of strings which describes the error. This field is present if there was 
 
 ## Understand rate limits in the DCS
 
-DCS handles up to 50 requests in total every 10 seconds.
+The DCS can handle up to 50 requests in total every 10 seconds.
 
-This rate limit is divided fairly between the organisations connected to DCS for the pilot.
+As a pilot participant, you will be subject to the following rate limits. Both use a sliding window rate limit algorithm.
+
+1. An overall rate limit of 50 requests every 10 seconds. This is shared between all pilot participants.
+1. An individual rate limit of (300 / number of participants) requests every 60 seconds. For instance, if 10 participants join the pilot, you would have an individual rate limit of 30 requests every 60 seconds.
+
+We may change these rate limits in future to better meet your needs.
 
 ### Tracking your rate limit usage
 
@@ -221,8 +226,8 @@ The DCS's HTTP response headers contain information such as:
 
 When you exceed the rate limit, the DCS returns a:
 
-+ 503 (Service unavailable) HTTP status code if, at the time you submit a request, the combined total traffic from all pilot organisations is over the rate limit
-+ 429 (Too many requests) HTTP status code if you have gone over your individual share of the limit
++ 503 (Service unavailable) HTTP status code if, at the time you submit a request, the combined total traffic from all pilot organisations is over the overall rate limit
++ 429 (Too many requests) HTTP status code if you have gone over your individual rate limit
 
 In both cases, the [`Retry-After`][Retry-After] HTTP header specifies how many seconds you should wait before retrying.
 


### PR DESCRIPTION
## Why

Since the rate limit text was first written, we have agreed our initial rate limit. Since we now know how long the window will be, we can tell clients to help them prepare.

We cannot give a precise number at this stage. Commercial confidentiality means we will be unable to until all possible pilot participants have decided one way or the other. In the interim, use an indicative number that is within an order of magnitude of the expected final number (i.e. in the range 1 to 100).

## What

Provide more guidance on the expected rate limit for pilot participants.