### PR TITLE
FjWF1vJ0: give Ben and Beth approval rights

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # See https://help.github.com/en/articles/about-code-owners
-* @alphagov/verify-tech-team-dcs @alphagov/team-gds-tech-writers
+* @alphagov/verify-tech-team-dcs @alphagov/team-gds-tech-writers @alphagov/verify-dcs-docs


### PR DESCRIPTION


## Why

@benjamin-mortimer has been doing a lot of of docs work lately. It seems like an oversight that he is unable to approve PRs in this repo.

## What


Make everyone in the [verify-dcs-docs](https://github.com/orgs/alphagov/teams/verify-dcs-docs) team a code owner. Ben and Beth (?) are the only people who will be affected by this. They will now have the power to approve PRs for this repo. They still won't be able to merge PRs, though.

Membership of the verify-dcs-docs team is managed in terraform.
