### PR TITLE
BAU: Scheduled review requested by the spaniel

### DIFF
--- a/source/api-reference.html.md.erb
+++ b/source/api-reference.html.md.erb
@@ -1,8 +1,8 @@
 ---
 title: API reference
 weight: 6
-last_reviewed_on: 2020-05-06
-review_in: 3 weeks
+last_reviewed_on: 2020-05-29
+review_in: 6 weeks
 ---
 
 # API reference
@@ -43,10 +43,11 @@ If the DCS is available, the JSON response body will be similar to:
 }
 ```
 
+Please note the `scheduledOutages` field is deprecated and will always contain and empty array.
+
 If the DCS is unavailable, the `message` field in the response describes the cause. The cause for unavailability can be:
 
 * `Limit exceeded` - you have exceeded your allocated number of API calls
-* `Planned outage in progress finishing <TIMESTAMP>` - the DCS or HM Passport Office (HMPO) are in a period of scheduled downtime, ending at `<TIMESTAMP>`
 * `Unplanned outage` - the DCS or HMPO are experiencing a period of unscheduled downtime
 
 For example, during a planned outage, the response is similar to:
@@ -54,15 +55,7 @@ For example, during a planned outage, the response is similar to:
 ```json
 {
   "available": false,
-  "message": "Planned outage in progress finishing 2019-09-12T00:00:00.000Z",
-  "scheduledOutages":
-    [
-      {
-      	"start":"2019-09-05T00:00:00.000Z",
-      	"end":"2019-09-12T00:00:00.000Z",
-      	"message":"Maintenance work is underway."
-      }
-    ]
+  "message": "Unplanned outage",
 }
 ```
 
@@ -71,18 +64,6 @@ Boolean field indicating if the DCS is available and serving requests.
 
 #### message
 A string explaining why the DCS is unavailable. For example, if there is an ongoing planned outage, the field will contain detail about the duration of the outage.
-
-#### scheduledOutages
-A list of upcoming scheduled outages. The list is empty if there are no outages.
-
-#### scheduledOutages.start
-String in ISO 8601 format indicating when an outage is scheduled to start.
-
-#### scheduledOutages.end
-String in ISO 8601 format indicating when an outage is scheduled to end.
-
-#### scheduledOutages.message
-String indicating the reason for the scheduled outage.
 
 ## Check passport validity
 
@@ -140,10 +121,7 @@ The passport expiration date in YYYY-MM-DD format. Must be in the future or no m
 
 A successful request is one that completes without error, regardless of whether the passport is valid or not.
 
-The DCS returns a:
-
-* `200` [HTTP response code][status-response-codes] for successful requests
-* `503` [HTTP response code][status-response-codes] if HMPO is having a planned outage
+The DCS returns a `200` [HTTP response code][status-response-codes] for successful requests, non-successful responses will return [as documented here][status-response-codes].
 
 Example response body for a valid passport:
 

--- a/source/api-reference.html.md.erb
+++ b/source/api-reference.html.md.erb
@@ -43,7 +43,7 @@ If the DCS is available, the JSON response body will be similar to:
 }
 ```
 
-Please note the `scheduledOutages` field is deprecated and will always contain and empty array.
+Please note the `scheduledOutages` field is deprecated and will always contain an empty array.
 
 If the DCS is unavailable, the `message` field in the response describes the cause. The cause for unavailability can be:
 

--- a/source/api-reference.html.md.erb
+++ b/source/api-reference.html.md.erb
@@ -50,7 +50,7 @@ If the DCS is unavailable, the `message` field in the response describes the cau
 * `Limit exceeded` - you have exceeded your allocated number of API calls
 * `Unplanned outage` - the DCS or HMPO are experiencing a period of unscheduled downtime
 
-For example, during a planned outage, the response is similar to:
+For example, during a unplanned outage, the response will be:
 
 ```json
 {

--- a/source/api-reference.html.md.erb
+++ b/source/api-reference.html.md.erb
@@ -121,7 +121,9 @@ The passport expiration date in YYYY-MM-DD format. Must be in the future or no m
 
 A successful request is one that completes without error, regardless of whether the passport is valid or not.
 
-The DCS returns a `200` [HTTP response code][status-response-codes] for successful requests, non-successful responses will return [as documented here][status-response-codes].
+The DCS returns a `200` [HTTP response code][status-response-codes] for successful requests. 
+
+If the requests are not successful, the DCS will return a [HTTP response code][status-response-codes] to indicate why the request was not successful.
 
 Example response body for a valid passport:
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,8 +1,8 @@
 ---
 title: The Document Checking Service pilot
 weight: 1
-last_reviewed_on: 2020-04-07
-review_in: 6 weeks
+last_reviewed_on: 2020-05-29
+review_in: 3 months
 ---
 
 # The Document Checking Service pilot

--- a/source/status-response-codes.html.md.erb
+++ b/source/status-response-codes.html.md.erb
@@ -12,7 +12,7 @@ The Document Checking Service (DCS) uses standard [HTTP response code][HTTP-Stat
 | HTTP response code | Description                            |
 | ------------------ | -------------------------------------- |
 | 200                | The DCS handled your request successfully. |
-| 400                | Your JOSE payload is incorrectly formed, the error message will tell you what is wrong |
+| 400                | There is a problem with you request, the error message will tell you what is wrong. |
 | 403                | You have used up [your quota of DCS checks][quotas] and cannot make any more DCS checks. |
 | 404                | The DCS URI is incorrect.              |
 | 429                | You have exceeded your total allocated number of API calls or your rate limit. <p>The [`Retry-After`][Retry-After] HTTP header specifies how many seconds you should wait before retrying.</p> |

--- a/source/status-response-codes.html.md.erb
+++ b/source/status-response-codes.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Status response codes
 weight: 6
-last_reviewed_on: 2020-04-07
+last_reviewed_on: 2020-05-29
 review_in: 6 weeks
 ---
 
@@ -12,7 +12,8 @@ The Document Checking Service (DCS) uses standard [HTTP response code][HTTP-Stat
 | HTTP response code | Description                            |
 | ------------------ | -------------------------------------- |
 | 200                | The DCS handled your request successfully. |
-| 403                | You have used up [your quota of DCS checks][quotas] and cannot make any more DCS checks.
+| 400                | Your JOSE payload is incorrectly formed, the error message will tell you what is wrong |
+| 403                | You have used up [your quota of DCS checks][quotas] and cannot make any more DCS checks. |
 | 404                | The DCS URI is incorrect.              |
 | 429                | You have exceeded your total allocated number of API calls or your rate limit. <p>The [`Retry-After`][Retry-After] HTTP header specifies how many seconds you should wait before retrying.</p> |
 | 503                | The DCS is temporarily unavailable because of high traffic. <p>The [`Retry-After`][Retry-After] HTTP header specifies how many seconds you should wait before retrying.</p> |

--- a/source/status-response-codes.html.md.erb
+++ b/source/status-response-codes.html.md.erb
@@ -12,7 +12,7 @@ The Document Checking Service (DCS) uses standard [HTTP response code][HTTP-Stat
 | HTTP response code | Description                            |
 | ------------------ | -------------------------------------- |
 | 200                | The DCS handled your request successfully. |
-| 400                | There is a problem with you request, the error message will tell you what is wrong. |
+| 400                | There is a problem with your request - the error message will tell you what is wrong and how to fix it. |
 | 403                | You have used up [your quota of DCS checks][quotas] and cannot make any more DCS checks. |
 | 404                | The DCS URI is incorrect.              |
 | 429                | You have exceeded your total allocated number of API calls or your rate limit. <p>The [`Retry-After`][Retry-After] HTTP header specifies how many seconds you should wait before retrying.</p> |


### PR DESCRIPTION
## Why

Review prompted by Daniel the Manual Spaniel.

## What

Update review dates.
Include entry on `status-response-codes` page for `400` (Bad request), this should probably be fleshed out in a story.

Removed references to `503` planned outage and planned outage functionality in status responses as this is a deprecated feature.
