### PR TITLE
G34uCPYu: add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "BAU"


### PR DESCRIPTION

## Why


We want to make sure we keep our dependencies up to date. This will reduce our exposure to potential security vulnerabilities and let us fix them more quickly.

We use Dependabot for this, following the other DCS-related repositories.

## What

Add daily checks by Depenabot for our Ruby dependencies.