### PR TITLE
BAU: add link to status page

### DIFF
--- a/source/support.html.md.erb
+++ b/source/support.html.md.erb
@@ -13,6 +13,10 @@ Email <dcs-pilot-support@digital.cabinet-office.gov.uk> if you need technical or
 
 If you think you've discovered a security issue, email <dcs-pilot-support@digital.cabinet-office.gov.uk>.
 
+## Status page
+
+You can find the current status of the DCS on the [status page](https://verifystatus.digital.cabinet-office.gov.uk/). Subscribe to get notified about incidents.
+
 ## Documentation feedback
 
 If you'd like to offer feedback or report a problem with this documentation website, [open an issue on GitHub][github-issue].


### PR DESCRIPTION
## Why

Clients should be able to use this to find out the current status of the DCS and subscribe for incident notifications.

## What

Add a link to the GOV.UK Verify status page
