### PR TITLE
BAU: add custom lint for broken link partial use

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -2,6 +2,7 @@ require 'govuk_tech_docs'
 
 # Check for broken links
 require 'html-proofer'
+require_relative 'test'
 
 # Pretty URLs see https://middlemanapp.com/advanced/pretty-urls/
 activate :directory_indexes

--- a/test.rb
+++ b/test.rb
@@ -1,0 +1,13 @@
+require 'html-proofer'
+
+class BrokenLinkPartialReferences < ::HTMLProofer::Check
+  def run
+    @html.css('p').each do |node|
+      broken_link_match = node.to_s.match(/\[.+\]/)
+
+      if broken_link_match
+        add_issue("Broken partial link: " + broken_link_match[0], line: node.line)
+      end
+    end
+  end
+end


### PR DESCRIPTION

## Why

There are two ways of adding a link:

1. directly - `[foo](bar.com)`
2. using the [links partial](https://github.com/alphagov/dcs-pilot-docs/blob/master/source/partials/_links.erb) - `[bar]` or `[foo][bar]`, where the link partial has an entry for `[bar]` that points to `bar.com`.

We've previously had problems with broken links. This is solved for case 1, since html-proofer catches those. However, it is not able to catch broken links created by case two. These manifest as seeing `[foo][bar]` still present in the HTML output.

Add a linter to automatically catch these errors to reduce the amount of manual checking required.

## What

Create a new html-proofer checker that checks for broken links that try (but fail) to use the link partial.

This is a copy of the linter that we already using successfully in our internal docs - where it successfully caught a few broken links.

## How to review

In the Travis output, you should see it running `BrokenLinkPartialReferences`
