### PR TITLE
add gdoc content about enrolling with the DCS certificate authority

### DIFF
--- a/source/enrol-with-the-DCS-certificate-authority.html.md.erb
+++ b/source/enrol-with-the-DCS-certificate-authority.html.md.erb
@@ -1,0 +1,75 @@
+---
+title: Enrol with the DCS certificate authority
+weight: 4.2
+last_reviewed_on: 2020-07-10
+review_in: 2 months
+---
+
+# Enrol with the DCS certificate authority
+
+Before you can [raise certificate signing requests (CSRs)](/generate-keys-and-request-certificates/#create-a-certificate-signing-request-csr), you’ll need to enrol with the DCS certificate authority (CA).
+
+To help you enrol, the DCS CA needs contact information for certain people within your organisation.
+
+1. [Provide details for a lead contact](/enrol-with-the-DCS-certificate-authority/#provide-details-for-a-lead-contact).
+1. [Understand the roles and responsibilities of certificate management](/enrol-with-the-DCS-certificate-authority/#understand-the-roles-and-responsibilities-of-certificate-management).
+1. [Provide details for your certificate requesters and approvers](/enrol-with-the-DCS-certificate-authority/#provide-details-for-your-certificate-requesters-and-approvers).
+1. [Provide details for a group inbox](/enrol-with-the-DCS-certificate-authority/#provide-details-for-a-group-inbox).
+
+## Provide details for a lead contact
+
+You need to provide contact details for a lead contact within your organisation.
+
+This person needs to be in a relatively senior role, for example, a service manager or programme lead.
+
+The lead contact will need to [send an email to idappki@digital.cabinet-office.gov.uk](mailto:idappki@digital.cabinet-office.gov.uk) confirming their:
+
+* first name
+* last name
+* email address
+* telephone number
+
+## Understand the roles and responsibilities of certificate management
+
+Once you have provided contact details for a lead contact, the DCS CA will send some documents to the lead contact. These documents outline the responsibilities of certificate management, for example how to raise certificate signing requests and certificate compliance.
+
+<%= warning_text('For security reasons, these documents must not be shared with anyone other than the lead contact and the certificate requesters and approvers the lead contact chooses.
+') %>
+
+## Provide details for your certificate requesters and approvers
+
+Once the DCS CA has the lead contact’s details, the DCS CA will ask the lead contact to choose at least 2 people for each of the following roles:
+
+* certificate requesters - the people who will raise your CSRs (for security reasons, you should keep the number of requesters to a minimum)
+* approvers who will approve your CSRs - approvers must be in a senior role within your organisation, for example, a project manager with responsibility for security
+
+Certificate requesters and approvers must be different people.
+
+The lead contact will need to [send an email to idappki@digital.cabinet-office.gov.uk](mailto:idappki@digital.cabinet-office.gov.uk) confirming the requesters’ and approvers’:
+
+* first names
+* last names
+* email addresses
+* telephone numbers
+
+Make sure the requesters know who the approvers are, and the approvers know who the requesters are.
+
+### Confirming your certificate requesters and approvers
+
+After the lead contact sends the contact details for the certificate requesters and approvers, the DCS CA performs 2 checks.
+
+1. The DCS CA rings the approvers on the approvers’ registered phone numbers and asks the approvers to confirm who the requesters are.
+1. The DCS CA rings the certificate requesters on the certificate requesters’ registered phone numbers and asks the requesters to confirm who the approvers are.
+
+Once the DCS CA has confirmation from the certificate requesters and approvers, they will add these details to their list of approved requesters and approvers.
+
+If the DCS CA receives a certificate signing request from someone who is not an approved requester, the DCS CA will not issue a certificate.
+
+## Provide details for a group inbox
+
+Setting up a group inbox is optional but will help make sure you receive your certificates and renewal notices if your requesters or approvers are not available.
+
+If you set up a group inbox, the lead contact should [send an email to idappki@digital.cabinet-office.gov.uk](mailto:idappki@digital.cabinet-office.gov.uk) confirming the group inbox address.
+
+
+<%= partial "partials/links" %>

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: The Document Checking Service pilot
 weight: 1
-last_reviewed_on: 2020-05-29
+last_reviewed_on: 2020-06-29
 review_in: 3 months
 ---
 


### PR DESCRIPTION
## Why

Need documentation about how a user can enrol with the DCS certificate authority. 

## What

Documentation about how a user can enrol with the DCS certificate authority. 


