### PR TITLE
Say you must enrol with the CA before you can raise a CSR

### DIFF
--- a/source/generate-keys-and-request-certificates.html.md.erb
+++ b/source/generate-keys-and-request-certificates.html.md.erb
@@ -20,7 +20,7 @@ You’ll need to generate your keys and certificates using the following steps.
 1. Submit the CSR to the GDS Certificate Authority (CA).
 1. The GDS CA will issue your certificate, which can take up to 2 working days.
 
-The GDS CA must sign and issue the certificates.
+The GDS CA must sign and issue the certificates. You need to [enrol with the GDS CA](/enrol-with-the-DCS-certificate-authority/#enrol-with-the-dcs-certificate-authority) before you can raise a CSR.
 
 This documentation gives examples of how you’d follow this process using OpenSSL. You can use other methods if you prefer.
 


### PR DESCRIPTION
Adds a sentence to redirect users to the CA enrollment guide if they've come to the "generate keys and certificates" page first. Saves users wasting time raising a CSR that we won't be able to approve.
