### PR TITLE
ow4AXjYw: add secret baseline

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,108 @@
+{
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2020-07-30T11:24:10Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "README.md": [
+      {
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 89,
+        "type": "Basic Auth Credentials"
+      }
+    ],
+    "source/access-the-data-in-a-DCS-response.html.md.erb": [
+      {
+        "hashed_secret": "1bb41056571f7b9f3ec5e7c894ca06aaf72144d9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 78,
+        "type": "JSON Web Token"
+      }
+    ],
+    "source/sign-and-encrypt-a-DCS-payload.html.md.erb": [
+      {
+        "hashed_secret": "257d56529a4e74148097c4db4adcd7badf937568",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 82,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "cf5699e4ce8de30b304c79b248738053b9867b9d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 116,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "8f000db26e27bb0f99e0c4ca79ec2d1d04a34c80",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 117,
+        "type": "Base64 High Entropy String"
+      }
+    ]
+  },
+  "version": "0.13.1",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}


### PR DESCRIPTION

## Why

For https://github.com/alphagov/gds-pre-commit/

## What

Add a secret baseline - none of the things detected by `detect-secrets` are actually secret.
