### PR TITLE
7LG7Kop7: Remove SHA1 thumbprint as a necessary JWS header

### DIFF
--- a/source/Set-up-your-JOSE-certificate-thumbprints.html.md.erb
+++ b/source/Set-up-your-JOSE-certificate-thumbprints.html.md.erb
@@ -66,9 +66,9 @@ You must then decode the Base64 string to get the binary DER.
 
 Use a library or a command line tool to hash the certificate.
 
-You need to generate SHA1 and SHA256 hashes of your certificate’s binary DER.
+You need to generate the SHA256 hash of your certificate’s binary DER.
 
-For each hash, you need to:
+You need to:
 
 1. Make sure the hash is in raw bytes - some tools return a Base64 string or hex string by default.
 1. Encode the bytes into Base64url.
@@ -83,6 +83,6 @@ If your library or command line tool cannot encode bytes to Base64url directly, 
 
 ## Use the thumbprints to build a JWS or JWE object
 
-Once you’ve created your SHA1 and SHA256 hashes, you can use them to [sign and encrypt your DCS payload](/sign-and-encrypt-a-DCS-payload/#sign-and-encrypt-a-dcs-payload).
+Once you’ve created your SHA256 hash, you can use it to [sign and encrypt your DCS payload](/sign-and-encrypt-a-DCS-payload/#sign-and-encrypt-a-dcs-payload).
 
 <%= partial "partials/links" %>

--- a/source/sign-and-encrypt-a-DCS-payload.html.md.erb
+++ b/source/sign-and-encrypt-a-DCS-payload.html.md.erb
@@ -68,17 +68,15 @@ The JWS headers contain information about how you have signed the payload, along
 
 For the DCS, you need to set the following headers:
 
-1. `x5t` contains the SHA1 thumbprint of your certificate.
 1. `x5t#S256` contains the SHA256 thumbprint of your certificate.
 1. `alg` must be set to one of: `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, or `PS512`.
 
-You must set the `x5t` and `x5t#S256` headers. To set them, you’ll need to have [generated thumbprints for your signing certificate](/Set-up-your-JOSE-certificate-thumbprints).
+You must set the `x5t#S256` header. To set it, you’ll need to have [generated thumbprints for your signing certificate](/Set-up-your-JOSE-certificate-thumbprints).
 
 Depending on the library you use, you might have to manually construct the JWS header. Your header should look like this:
 
 ```json
 {
-  "x5t":"K9gFum5l_xYyHwCniYljJ4Lh_vY",
   "x5t#S256":"gGzb5v_MNfiC0QHur40xZpZyKCVzy7KeZyzFCVi_BrI",
   "alg":"RS256"
 }


### PR DESCRIPTION
## Why

These docs claim that we mandate both SHA1 and SHA256 thumbprint headers in the JWS payload layers, while this isn't strictly true.

## What

This PR removes references to SHA1 from the doc as SHA256 is the preferred thumbprint. 
