### PR TITLE
BAU: remove requirement for SHA1 header in JWEs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-07-30T11:24:10Z",
+  "generated_at": "2020-08-28T13:19:41Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -81,21 +81,14 @@
         "hashed_secret": "257d56529a4e74148097c4db4adcd7badf937568",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 82,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "cf5699e4ce8de30b304c79b248738053b9867b9d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 116,
+        "line_number": 80,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "8f000db26e27bb0f99e0c4ca79ec2d1d04a34c80",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 117,
+        "line_number": 113,
         "type": "Base64 High Entropy String"
       }
     ]

--- a/source/Set-up-your-JOSE-certificate-thumbprints.html.md.erb
+++ b/source/Set-up-your-JOSE-certificate-thumbprints.html.md.erb
@@ -17,7 +17,7 @@ If you need to create the thumbprints manually yourself, you’ll need to:
 
 1. Check your certificate is in binary DER format.
 1. Hash the binary representation of the certificate.
-1. Use the thumbprints to build a JWS or JWE object.
+1. Use the thumbprint to build a JWS or JWE object.
 
 ## Check your certificate is in binary DER format
 
@@ -81,7 +81,7 @@ If your library or command line tool cannot encode bytes to Base64url directly, 
 1. Encode the bytes to Base64.
 1. Convert the Base64 string to Base64url in your own code.
 
-## Use the thumbprints to build a JWS or JWE object
+## Use the thumbprint to build a JWS or JWE object
 
 Once you’ve created your SHA256 hash, you can use it to [sign and encrypt your DCS payload](/sign-and-encrypt-a-DCS-payload/#sign-and-encrypt-a-dcs-payload).
 

--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -58,9 +58,7 @@
 [jwe-alg-header]: https://www.rfc-editor.org/rfc/rfc7516.html#section-4.1.1
 [jwe-enc-header]: https://www.rfc-editor.org/rfc/rfc7516.html#section-4.1.2
 [jws-alg-header]: https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1.1
-[jws-x5t-header]: https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1.7
 [jws-x5t256-header]: https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1.8
-[jwe-x5t-header]: https://www.rfc-editor.org/rfc/rfc7516.html#section-4.1.9
 [jwe-x5t256-header]: https://www.rfc-editor.org/rfc/rfc7516.html#section-4.1.10
 [supported-JWE-encodings]: https://www.rfc-editor.org/rfc/rfc7518.html#section-5.1
 

--- a/source/sign-and-encrypt-a-DCS-payload.html.md.erb
+++ b/source/sign-and-encrypt-a-DCS-payload.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Sign and encrypt a DCS payload
 weight: 4.6
-last_reviewed_on: 2020-06-30
+last_reviewed_on: 2020-08-27
 review_in: 2 months
 ---
 
@@ -64,14 +64,14 @@ We recommend using [version 4 UUIDs](https://tools.ietf.org/html/rfc4122#section
 
 ## Create JWS headers
 
-The JWS headers contain information about how you have signed the payload, along with certificate thumbprints which allow the DCS to look up which certificate you’re using.
+The JWS headers contain information about how you have signed the payload, along with a certificate thumbprint which allows the DCS to look up which certificate you’re using.
 
 For the DCS, you need to set the following headers:
 
 1. `x5t#S256` contains the SHA256 thumbprint of your certificate.
 1. `alg` must be set to one of: `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, or `PS512`.
 
-You must set the `x5t#S256` header. To set it, you’ll need to have [generated thumbprints for your signing certificate](/Set-up-your-JOSE-certificate-thumbprints).
+You must set the `x5t#S256` header. To set it, you’ll need to have [generated a thumbprint for your signing certificate](/Set-up-your-JOSE-certificate-thumbprints).
 
 Depending on the library you use, you might have to manually construct the JWS header. Your header should look like this:
 
@@ -99,10 +99,9 @@ You must set the following headers:
 * `enc` must be set to a value [permitted by RFC 7518][supported-JWE-encodings], for example `A128CBC-HS256`
 * `alg` must be set to `RSA-OAEP-256`
 * `typ` must be set to `JWE`
-* `x5t` contains the SHA1 thumbprint of the DCS encryption certificate
 * `x5t#S256` contains the SHA256 thumbprint of the DCS encryption certificate
 
-You must set the `x5t` and `x5t#S256` headers. To set them, you’ll need to have [generated thumbprints for the DCS encryption certificate](/Set-up-your-JOSE-certificate-thumbprints). The DCS will not accept the JWS or JWE objects without these headers.
+You must set the `x5t#S256` header. To set it, you’ll need to have [generated a thumbprint for the DCS encryption certificate](/Set-up-your-JOSE-certificate-thumbprints).
 
 Your header should look like this:
 
@@ -111,10 +110,10 @@ Your header should look like this:
   "enc":"A128CBC-HS256",
   "alg":"RSA-OAEP-256",
   "typ":"JWE",
-  "x5t":"xiWgxFMOIw1M4m9LYCnKZk5eHJs",
   "x5t#S256":"PJLEl_B6MFKaMEG6HK7BBdaueJc7e-SiimQfvEpTYj4"
 }
 ```
+
 ### Using encryption algorithms
 
 The encrypted component of the JSON Object Signing and Encryption (JOSE) message must use:


### PR DESCRIPTION
## Why

We no longer need the SHA1 header in JWEs. Remove the requirement to save new clients some work. If clients choose to send the header, that's fine - we'll just ignore it.

This follows on from https://github.com/alphagov/dcs-pilot-docs/pull/203, which did the same for JWS.

DCS people - look at Decrypter.java to see how the header is/was used.

## What

Remove the requirement to provide the `x5t` (SHA1) header in JWEs.

Also remove some unused links and un-pluralise instances of 'thumbprints'.