### PR TITLE
Add enroling with the DCS CA to the list of steps to integrate with DCS

### DIFF
--- a/source/integrating-with-the-dcs.html.md.erb
+++ b/source/integrating-with-the-dcs.html.md.erb
@@ -24,7 +24,7 @@ Your client will need to be able to sign and encrypt JSON data and make HTTP req
 
 To build a working DCS client, you'll need to:
 
-1. [Enrol with the DCS certificate authority](https://dcs-pilot-docs.cloudapps.digital/enrol-with-the-DCS-certificate-authority/#enrol-with-the-dcs-certificate-authority)
+1. [Enrol with the DCS certificate authority](https://dcs-pilot-docs.cloudapps.digital/enrol-with-the-DCS-certificate-authority/#enrol-with-the-dcs-certificate-authority).
 1. [Generate keys and request certificates](/generate-keys-and-request-certificates/#generate-keys-and-request-certificates) - you’ll need to [contact DCS support](/support/#support) to get the Public Key Infrastructure (PKI) information so you can get started with integrating with the DCS.
 1. [Create a network connection to the DCS](/create-a-network-connection/#create-a-network-connection-to-the-dcs) using mutual authentication.
 1. [Set up your JOSE certificate thumbprints](/Set-up-your-JOSE-certificate-thumbprints/#set-up-your-jose-certificate-thumbprints).

--- a/source/integrating-with-the-dcs.html.md.erb
+++ b/source/integrating-with-the-dcs.html.md.erb
@@ -24,7 +24,8 @@ Your client will need to be able to sign and encrypt JSON data and make HTTP req
 
 To build a working DCS client, you'll need to:
 
-1. [Generate keys and request certificates](/generate-keys-and-request-certificates/#generate-keys-and-request-certificates) - you’ll [contact DCS support](/support/#support) to get the Public Key Infrastructure (PKI) information so you can get started with integrating with the DCS.
+1. [Enrol with the DCS certificate authority](https://dcs-pilot-docs.cloudapps.digital/enrol-with-the-DCS-certificate-authority/#enrol-with-the-dcs-certificate-authority)
+1. [Generate keys and request certificates](/generate-keys-and-request-certificates/#generate-keys-and-request-certificates) - you’ll need to [contact DCS support](/support/#support) to get the Public Key Infrastructure (PKI) information so you can get started with integrating with the DCS.
 1. [Create a network connection to the DCS](/create-a-network-connection/#create-a-network-connection-to-the-dcs) using mutual authentication.
 1. [Set up your JOSE certificate thumbprints](/Set-up-your-JOSE-certificate-thumbprints/#set-up-your-jose-certificate-thumbprints).
 1. [Sign and encrypt a DCS payload](/sign-and-encrypt-a-DCS-payload/#sign-and-encrypt-a-dcs-payload).


### PR DESCRIPTION
We added a guide to the pilot docs about how to enrol with the DCS certificate authority. But we didn't add enrolling with the CA to the list of steps participants take to integrate with DCS. It's an important step and comes with a lead time, so I've added it.