### PR TITLE
Explain you must sign a contract before enrolling

### DIFF
--- a/source/enrol-with-the-DCS-certificate-authority.html.md.erb
+++ b/source/enrol-with-the-DCS-certificate-authority.html.md.erb
@@ -7,7 +7,9 @@ review_in: 2 months
 
 # Enrol with the DCS certificate authority
 
-Before you can [raise certificate signing requests (CSRs)](/generate-keys-and-request-certificates/#create-a-certificate-signing-request-csr), you’ll need to enrol with the DCS certificate authority (CA).
+Before you can [raise certificate signing requests (CSRs)](/generate-keys-and-request-certificates/#create-a-certificate-signing-request-csr), you need to enrol with the DCS certificate authority (CA).
+
+You need to sign a contract for the DCS pilot before you can enrol with the CA.
 
 To help you enrol, the DCS CA needs contact information for certain people within your organisation.
 

--- a/source/enrol-with-the-DCS-certificate-authority.html.md.erb
+++ b/source/enrol-with-the-DCS-certificate-authority.html.md.erb
@@ -9,7 +9,7 @@ review_in: 2 months
 
 Before you can [raise certificate signing requests (CSRs)](/generate-keys-and-request-certificates/#create-a-certificate-signing-request-csr), you need to enrol with the DCS certificate authority (CA).
 
-You need to sign a contract for the DCS pilot before you can enrol with the CA.
+You need to sign a contract for the DCS pilot before you can enrol with the CA. [Contact DCS support](https://dcs-pilot-docs.cloudapps.digital/support/#support) if you need help with your contract. 
 
 To help you enrol, the DCS CA needs contact information for certain people within your organisation.
 


### PR DESCRIPTION
Pilot participants need to sign a contract before they can begin the CA enrolment process. We should point this out in our documentation.