### PR TITLE
fixed headings in accessibility to be compliant with regulations

### DIFF
--- a/source/accessibility-statement.html.md.erb
+++ b/source/accessibility-statement.html.md.erb
@@ -44,9 +44,17 @@ The Equality and Human Rights Commission (EHRC) is responsible for enforcing the
 
 GDS is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
 
-### Compliance status
+## Compliance status
 
-This website is partially compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard, as parts of this documentation are not accessible because of [issues caused by our Technical Documentation](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation).
+This website is partially compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard, due to the non-compliances listed below.
+
+### Non-accessible content
+
+The content listed below is non-accessible for the following reasons.
+
+#### Non-compliance with the accessibility regulations
+
+Some parts of this documentation are not fully accessible because of [issues caused by our Technical Documentation](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation).
 
 ## How we tested this website
 


### PR DESCRIPTION
## Why

Need specific headings in our accessibility statement to make any non-compliances clear.

## What

Need specific headings in our accessibility statement to make any non-compliances clear.

