### PR TITLE
made it more clear that a user will have to enrol with the DCS CA before they can raise a CSR

### DIFF
--- a/source/generate-keys-and-request-certificates.html.md.erb
+++ b/source/generate-keys-and-request-certificates.html.md.erb
@@ -13,14 +13,9 @@ To send requests to the Document Checking Service (DCS) you’ll need to generat
 * JSON signing
 * JSON encryption
 
-You’ll need to generate your keys and certificates using the following steps.
+You request the certificates by raising a certificate signing request (CSR).
 
-1. Generate a private RSA key.
-1. Create a Certificate Signing Request (CSR).
-1. Submit the CSR to the GDS Certificate Authority (CA).
-1. The GDS CA will issue your certificate, which can take up to 2 working days.
-
-The GDS CA must sign and issue the certificates. You need to [enrol with the GDS CA](/enrol-with-the-DCS-certificate-authority/#enrol-with-the-dcs-certificate-authority) before you can raise a CSR.
+You must [enrol with the GDS Certificate Authority (CA)](/enrol-with-the-DCS-certificate-authority/#enrol-with-the-dcs-certificate-authority) before you can raise a Certificate Signing Request (CSR).
 
 This documentation gives examples of how you’d follow this process using OpenSSL. You can use other methods if you prefer.
 

--- a/source/generate-keys-and-request-certificates.html.md.erb
+++ b/source/generate-keys-and-request-certificates.html.md.erb
@@ -15,7 +15,7 @@ To send requests to the Document Checking Service (DCS) you’ll need to generat
 
 You request the certificates by raising a certificate signing request (CSR).
 
-You must [enrol with the GDS Certificate Authority (CA)](/enrol-with-the-DCS-certificate-authority/#enrol-with-the-dcs-certificate-authority) before you can raise a Certificate Signing Request (CSR).
+You must [enrol with the GDS Certificate Authority (CA)](/enrol-with-the-DCS-certificate-authority/#enrol-with-the-dcs-certificate-authority) before you can raise a CSR. The GDS CA will issue your certificate, which can take up to 2 working days.
 
 This documentation gives examples of how you’d follow this process using OpenSSL. You can use other methods if you prefer.
 


### PR DESCRIPTION

## Why

Not very clear that a user has to enrol with DCS CA before raising a CSR

## What

Moved section further up and removed confusing information to make user focus on what they need to do 
