### PR TITLE
Tweak CSR turnaround time content

### DIFF
--- a/source/generate-keys-and-request-certificates.html.md.erb
+++ b/source/generate-keys-and-request-certificates.html.md.erb
@@ -15,7 +15,9 @@ To send requests to the Document Checking Service (DCS) you’ll need to generat
 
 You request the certificates by raising a certificate signing request (CSR).
 
-You must [enrol with the GDS Certificate Authority (CA)](/enrol-with-the-DCS-certificate-authority/#enrol-with-the-dcs-certificate-authority) before you can raise a CSR. The GDS CA will issue your certificate, which can take up to 2 working days.
+You must [enrol with the GDS Certificate Authority (CA)](/enrol-with-the-DCS-certificate-authority/#enrol-with-the-dcs-certificate-authority) before you can raise a CSR.
+
+It can take up to 2 working days to process the CSR.
 
 This documentation gives examples of how you’d follow this process using OpenSSL. You can use other methods if you prefer.
 


### PR DESCRIPTION
## What

Move the info about the 2 day turnaround time for CSRs onto its own line 

## Why

To avoid users potentially misinterpreting it as the turnaround time for onboarding to the CA.