### PR TITLE
Change the tenses on the docs homepage from future to present

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -7,9 +7,9 @@ review_in: 3 months
 
 # The Document Checking Service pilot
 
-This technical documentation is for organisations taking part in the [Document Checking Service (DCS) pilot][govuk-link]. The pilot will allow organisations to digitally check the validity of British passports.
+This technical documentation is for organisations taking part in the [Document Checking Service (DCS) pilot][govuk-link]. The pilot allows organisations to digitally check the validity of British passports.
 
-We will start onboarding selected pilot participants in early 2020.
+We are currently onboarding selected pilot participants.
 
 We will be refining the onboarding process as we go, and participants should therefore be aware that the process may change between iterations.
 


### PR DESCRIPTION
The docs homepage refers to things which are happening now as things which will happen in future.

I think we should maybe return to this and re-think what the page is for. (@PippaClarkGDS)