### PR TITLE
Move prod access guide down the navigation order

### DIFF
--- a/source/getting-access-to-production.html.md.erb
+++ b/source/getting-access-to-production.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Request access to production
-weight: 2
+weight: 5
 last_reviewed_on: 2020-10-12
 review_in: 8 weeks
 ---


### PR DESCRIPTION
Should sit as the last connecting step after "Access the data in a DCS response"