### PR TITLE
uploaded gdoc content and created a page in docs

### DIFF
--- a/source/api-reference.html.md.erb
+++ b/source/api-reference.html.md.erb
@@ -43,7 +43,7 @@ If the DCS is available, the JSON response body will be similar to:
 }
 ```
 
-For the DCS pilot participants, the `scheduledOutages` field will be empty. 
+The `scheduledOutages` field is a legacy field provided for compatibility reasons for older clients and is always empty for participants of the DCS pilot.
 
 If the DCS is unavailable, the `message` field in the response describes the reason. The reason for the DCS being unavailable can be:
 

--- a/source/helping-your-users.html.md.erb
+++ b/source/helping-your-users.html.md.erb
@@ -1,0 +1,40 @@
+---
+title: Helping your users with their passport queries
+weight: 5.4
+last_reviewed_on: 2020-10-16
+review_in: 8 weeks
+---
+
+# Helping your users with their passport queries
+
+It’s possible that as a result of using your service, a user might think something is wrong with their passport. This documentation will help you answer your users’ passport queries.
+
+1. Be aware of known `valid: false` passport issues.
+1. Allow your users to have the check made again.
+1. Consider offering your users an alternative route.
+1. Direct your users to the Passport Advice Line.
+
+## Be aware of known `valid: false` passport issues
+
+There’s a known issue with readings from NFC chips. Some users may receive a false-negative result. The Document Checking Service (DCS) has provided you with [guidance on how to reduce errors when using data from a passport chip](/reading-data-from-passport-nfc-chip/#reduce-errors-when-using-data-from-a-passport-chip).
+
+To make your users aware of this known possible issue, you could:
+
+* reiterate this information in a separate email to your users
+* flag this as a possible issue when you’re building your service so a user can adjust their input
+
+## Allow your users to have the check made again
+
+If the check fails for any reason, for example a user misspelling their name, you should allow your users to re-enter their details and have the check made again.
+
+## Consider offering your users an alternative route
+
+Your service could give users an alternative way to use the service if they do not have a British passport, or do not want their passport details to be checked in this way. A user can use this alternative route to access your service without a DCS check being made.
+
+However, even though a user can now access your service, they may still have concerns about their passport validity. If this is the case, you should direct your users to the Passport Advice Line.
+
+## Direct your users to the Passport Advice Line
+
+If a DCS check has returned a `valid: false` response, your users may still have doubts about whether their passport is valid (or red-flagged).
+
+You should [direct users in this position to the Passport Advice Line](https://www.gov.uk/passport-advice-line). This final check will give your users reassurance about whether their passport is valid.

--- a/source/helping-your-users.html.md.erb
+++ b/source/helping-your-users.html.md.erb
@@ -16,7 +16,7 @@ It’s possible that as a result of using your service, a user might think somet
 
 ## Be aware of known `valid: false` passport issues
 
-There’s a known issue with readings from NFC chips. Some users may receive a false-negative result. The Document Checking Service (DCS) has provided you with [guidance on how to reduce errors when using data from a passport chip](/reading-data-from-passport-nfc-chip/#reduce-errors-when-using-data-from-a-passport-chip).
+There’s a known issue with readings from the near-field communication (NFC) chips in passports. Some users may receive a false-negative result. There's [guidance on how to reduce errors when using data from a passport chip](/reading-data-from-passport-nfc-chip/#reduce-errors-when-using-data-from-a-passport-chip).
 
 To make your users aware of this known possible issue, you could:
 
@@ -25,13 +25,16 @@ To make your users aware of this known possible issue, you could:
 
 ## Allow your users to have the check made again
 
-If the check fails for any reason, for example a user misspelling their name, you should allow your users to re-enter their details and have the check made again.
+It's likely that a check will have failed due to user error, for example a user misspelling their name. Allowing your users to re-enter their details and have the check made again can help solve this problem.
 
 ## Consider offering your users an alternative route
 
-Your service could give users an alternative way to use the service if they do not have a British passport, or do not want their passport details to be checked in this way. A user can use this alternative route to access your service without a DCS check being made.
+You could offer your users alternative routes to access your service for example:
 
-However, even though a user can now access your service, they may still have concerns about their passport validity. If this is the case, you should direct your users to the Passport Advice Line.
+- if a user does not want to provide their passport details over the internet, you could offer them an in-person alternative
+- if a user fails a DCS check, you could provide an alternative route to access your service without a DCS check being made
+
+Even if a user can access your service through an alternative route, they may still have concerns about their passport validity. If this is the case, you should direct your users to the Passport Advice Line.
 
 ## Direct your users to the Passport Advice Line
 

--- a/source/helping-your-users.html.md.erb
+++ b/source/helping-your-users.html.md.erb
@@ -7,7 +7,9 @@ review_in: 8 weeks
 
 # Helping your users with their passport queries
 
-It’s possible that as a result of using your service, a user might think something is wrong with their passport. This documentation will help you answer your users’ passport queries.
+It’s possible a user may not believe the result of a DCS check is correct. For example, a user may make a mistake entering their passport details into your service and receive a `valid: false` response even though their passport is valid.
+
+This documentation will help you answer your users’ passport queries.
 
 1. Be aware of known `valid: false` passport issues.
 1. Allow your users to have the check made again.
@@ -38,6 +40,6 @@ Even if a user can access your service through an alternative route, they may st
 
 ## Direct your users to the Passport Advice Line
 
-If a DCS check has returned a `valid: false` response, your users may still have doubts about whether their passport is valid (or red-flagged).
+If a DCS check has returned a `valid: false` response, your users may have doubts about whether their passport is valid (or red-flagged).
 
-You should [direct users in this position to the Passport Advice Line](https://www.gov.uk/passport-advice-line). This final check will give your users reassurance about whether their passport is valid.
+You should direct users who are concerned about the status of their passport to the [Passport Advice Line](https://www.gov.uk/passport-advice-line). This final check will give your users reassurance about whether their passport is valid.


### PR DESCRIPTION
## Why

No documentation about how pilot participants can help answer their users' passport queries. 

## What

Documentation giving advice and guidance about how pilot participants can best help their users answer their passport queries. 

## How to review

If any major changes are suggested, this will have to go back through tech writer review. 