### PR TITLE
Change homepage tenses from future to present

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -2,7 +2,7 @@
 title: The Document Checking Service pilot
 weight: 1
 last_reviewed_on: 2020-12-02
-review_in: 3 months
+review_in: 6 months
 ---
 
 # The Document Checking Service pilot

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,15 +1,15 @@
 ---
 title: The Document Checking Service pilot
 weight: 1
-last_reviewed_on: 2020-10-19
+last_reviewed_on: 2020-12-02
 review_in: 3 months
 ---
 
 # The Document Checking Service pilot
 
-This technical documentation is for organisations taking part in the [Document Checking Service (DCS) pilot][govuk-link]. The pilot will allow organisations to digitally check the validity of British passports.
+This technical documentation is for organisations taking part in the [Document Checking Service (DCS) pilot][govuk-link]. The pilot allows organisations to digitally check the validity of British passports.
 
-We will start onboarding selected pilot participants in early 2020.
+We are currently onboarding selected pilot participants.
 
 We will be refining the onboarding process as we go, and participants should therefore be aware that the process may change between iterations.
 


### PR DESCRIPTION
The docs homepage references things that are currently happening as though they were going to happen in future. It also refers to "early 2020" as being in the future, but this date is now in the past.