### PR TITLE
updating accessibility statement review date to March 2021

### DIFF
--- a/source/accessibility-statement.html.md.erb
+++ b/source/accessibility-statement.html.md.erb
@@ -2,8 +2,8 @@
 title: Accessibility
 weight: 999
 hide_in_navigation: true
-last_reviewed_on: 2020-09-14
-review_in: 3 months
+last_reviewed_on: 2020-12-14
+review_in: 6 months
 ---
 # Accessibility
 ## Accessibility statement for the Document Checking Service pilot documentation
@@ -75,7 +75,7 @@ We used manual and automated tests to look for issues such as:
 
 ## What we’re doing to improve accessibility
 
-We plan to fix the other accessibility issues by [updating our Technical Documentation Template by the end of 2020](https://tdt-documentation.london.cloudapps.digital/accessibility#using-the-technical-documentation-template-for-your-own-documentation).
+We plan to fix the other accessibility issues by [updating our Technical Documentation Template by the end of March 2021](https://tdt-documentation.london.cloudapps.digital/accessibility#using-the-technical-documentation-template-for-your-own-documentation).
 
 This statement was prepared on 20 September 2019. It was last updated on 14 September 2020.
 


### PR DESCRIPTION
## Why

We mentioned the tech docs template accessibility issues should be fixed by 31 Dec 2020 but the date will now be March 2021.

## What

Updated the line to reflect the new date. 