### PR TITLE
BAU: Fix misleading text

### DIFF
--- a/source/Set-up-your-JOSE-certificate-thumbprints.html.md.erb
+++ b/source/Set-up-your-JOSE-certificate-thumbprints.html.md.erb
@@ -83,6 +83,6 @@ If your library or command line tool cannot encode bytes to Base64url directly, 
 
 ## Use the thumbprint to build a JWS or JWE object
 
-Once you’ve created your SHA256 hash, you can use it to [sign and encrypt your DCS payload](/sign-and-encrypt-a-DCS-payload/#sign-and-encrypt-a-dcs-payload).
+Once you’ve created your SHA256 hash, you can use it when you [sign and encrypt your DCS payload](/sign-and-encrypt-a-DCS-payload/#sign-and-encrypt-a-dcs-payload).
 
 <%= partial "partials/links" %>


### PR DESCRIPTION
Update  "Set up your JOSE certificate thumbprints" doc to fix misleading text.

The certificate thumbprint is used *when* signing and encrypting DCS payloads, not *to* sign and encrypt DCS payloads.
