### PR TITLE
zyMOmoE7: Add cert rotation doc

### DIFF
--- a/source/rotating-keys-and-certificates.html.md.erb
+++ b/source/rotating-keys-and-certificates.html.md.erb
@@ -7,7 +7,7 @@ review_in: 6 months
 
 # Rotating keys and certificates
 
-When the certificates containing public keys are due to expire, they must replaced with new keys and certificates. We call this process certificate rotation. There are 2 sets of keys and certificates and each has different processes:
+When the certificates containing public keys are due to expire, they must replaced with new keys and certificates. We call this process certificate rotation. There are 2 sets of keys and certificates:
 
   * the keys you create and the associated certificates
   * the keys the Document Checking Service (DCS) creates and the associated certificates
@@ -16,28 +16,32 @@ When the certificates containing public keys are due to expire, they must replac
 
 When the certificates containing your public keys are due to expire, you must rotate them. If you do not, your connection to the DCS will stop working.
 
-1. The DCS will contact you to let you that your certificates need to be rotated.
+1. The DCS team will contact you to let you know that you need to rotate your certificates.
 1. Follow the process to [generate keys and request certificates](/generate-keys-and-request-certificates). You must generate new keys. Do not reuse old keys.
-1. When you receive the new certificates, [contact the DCS](/support) to inform them that you are ready to start using your new keys and certificates.
+1. When you receive the new certificates, [contact the DCS](/support) to inform us that you are ready to start using your new keys and certificates.
 1. Wait for confirmation that the DCS is ready to start using your new certificates.
-1. When DCS has confirmed we are ready, you can update your configuration to use the new keys and certificates.
+1. When the DCS has confirmed we are ready, you can update your configuration to use the new keys and certificates.
 
 
 ## Rotating the DCS certificates
 
-When the certificates containing DCS's public keys are due to expire, you must rotate them. If you do not, your connection to the DCS will stop working.
+When the certificates containing the DCS's public keys are due to expire, you must rotate them. If you do not, your connection to the DCS will stop working.
 
-The DCS will contact you to let you know that DCS's certificates will be rotated. We'll give you at least 1 month notice of the date when we will perform the rotation. 
+The DCS team will contact you to let you know that the DCS's certificates will be rotated. We'll give you at least one month's notice of the date when we will perform the rotation. 
 
-At least 1 week before the scheduled rotation, we'll send you the new signing and encryption certificates. Due to the nature of how the DCS uses these different certificates, there are different procedures for when they may be updated.
+At least one week before the scheduled rotation, we'll send you the new signing and encryption certificates. There are different processes for: 
+
+* using the new DCS signing certificate
+* using the new DCS encryption certificate
+
 
 ### Using the new DCS signing certificate
 
-If you are able to dual-run signing certificates in your service, you can start using the new DCS signing certificate as your secondary certificate straight away. However, you need to keep using the old certificate as your primary certificate until we rotate to the new key.
+If you're able to dual-run signing certificates in your service, you can start using the new DCS signing certificate as your secondary certificate straight away. However, you need to keep using the old certificate as your primary certificate until we rotate to the new key.
 
-The DCS will start using its new signing key at the scheduled time. We’ll let you know when we have rotated to the new key. After the DCS has rotated to the new key, you are free to remove the old certificate.
+The DCS will start using its new signing key at the scheduled time. The DCS team will let you know when we have rotated to the new key. After the DCS has rotated to the new key, you are free to remove the old certificate.
 
-If you are not able to dual-run signing certificates, we need you to join a coordinated rotation with us on the day. This means you'll need to join a conference call with us in which, simultaneously:
+If you're not able to dual-run signing certificates, you'll need to join a coordinated rotation with us on the day. This means you'll need to join a conference call with us in which, simultaneously:
 
   * we deploy a release of the DCS which uses its new signing key to sign messages
   * you deploy a release of your service which uses the new DCS signing certificate
@@ -46,17 +50,17 @@ If you are not able to dual-run signing certificates, we need you to join a coor
 
 You can start using the new DCS integration encryption certificate straight away, as the DCS can dual-run encryption keys. This means the DCS can accept messages which have been encrypted using either the old or new encryption certificate.
 
-If you are joining us for a coordinated rotation of your signing certificate, we recommend rotating your encryption certificate at the same time.
+If you're joining us for a coordinated rotation of your signing certificate, we recommend rotating your encryption certificate at the same time.
 
-We'll be removing the old encryption key shortly after switching the signing key during the scheduled call, so make sure you're using the new encryption certificate before then.
+We'll remove the old encryption key shortly after switching the signing key during the scheduled call, so make sure you're using the new encryption certificate before then.
 
 ## Enable dual running of the DCS signing certificates
 
-To avoid having to coordinate the rotation of a DCS signing certificate, we recommend that you implement dual running for this certificate in your code. Libraries that you may be using to support your connection may have builtin support for this or you may need to implement it yourself.
+To avoid having to coordinate the rotation of a DCS signing certificate, we recommend that you implement dual running for this certificate in your code. If you are not using a library with built-in support for this, you will need to implement it yourself.
 
 
 1. Make it possible to configure 2 DCS signing certificates.
-1. Generate a JOSE certificate thumbprint for these certificates using the same process as when you [Set up your JOSE certificate thumbprints](/set-up-your-JOSE-certificate-thumbprints/#set-up-your-jose-certificate-thumbprints) 
+1. Generate a JOSE certificate thumbprint for these certificates using the same process as when you [set up your JOSE certificate thumbprints](/set-up-your-JOSE-certificate-thumbprints/#set-up-your-jose-certificate-thumbprints) 
 1. Store the certificates in a map or dictionary using the JOSE thumbprint as the key.
 1. Use the JOSE certificate thumbprint from the DCS response to select which certificate to use.
 

--- a/source/rotating-keys-and-certificates.html.md.erb
+++ b/source/rotating-keys-and-certificates.html.md.erb
@@ -7,58 +7,58 @@ review_in: 6 months
 
 # Rotating keys and certificates
 
-When the certificates containing public keys are due to expire, they must replaced with new keys and certificates. We call this process certificate rotation. There are two set of keys and certificates that must be handled, with different processes for each set.
+When the certificates containing public keys are due to expire, they must replaced with new keys and certificates. We call this process certificate rotation. There are 2 sets of keys and certificates and each has different processes:
 
-  * The keys you create and the associated certificates.
-  * The keys DCS creates and the associated certificates.
+  * the keys you create and the associated certificates
+  * the keys the Document Checking Service (DCS) creates and the associated certificates
 
 ## Rotating your keys and certificates
 
 When the certificates containing your public keys are due to expire, you must rotate them. If you do not, your connection to the DCS will stop working.
 
-..1. DCS will contact you to let you that your certificates need to be rotated.
-  1. Follow the process to [generate keys and request certificates](/generate-keys-and-request-certificates). You must generate new keys. Do not reuse old keys.
-..1. When you receive the new certificates, contact DCS to inform them that you ready to start using your new keys and certificates.
-  1. Wait for confirmation that DCS is ready to start using your new certificates.
-  1. When DCS has confirmed that we are ready, you can update your configuration to use the new keys and certificates.
+1. The DCS will contact you to let you that your certificates need to be rotated.
+1. Follow the process to [generate keys and request certificates](/generate-keys-and-request-certificates). You must generate new keys. Do not reuse old keys.
+1. When you receive the new certificates, [contact the DCS](/support) to inform them that you are ready to start using your new keys and certificates.
+1. Wait for confirmation that the DCS is ready to start using your new certificates.
+1. When DCS has confirmed we are ready, you can update your configuration to use the new keys and certificates.
 
 
-## Rotating DCS certificates
+## Rotating the DCS certificates
 
 When the certificates containing DCS's public keys are due to expire, you must rotate them. If you do not, your connection to the DCS will stop working.
 
-DCS will contact you to let you know that DCS's certificates need to be rotated. We will give you at least 1 month notice of the date when we will perform the rotation. At least 1 week before the scheduled rotation we will send you the new signing and encryption certificates. Due to the nature of how these different certificates are used, there are different procedures for when they may be updated.
+The DCS will contact you to let you know that DCS's certificates will be rotated. We'll give you at least 1 month notice of the date when we will perform the rotation. 
+
+At least 1 week before the scheduled rotation, we'll send you the new signing and encryption certificates. Due to the nature of how the DCS uses these different certificates, there are different procedures for when they may be updated.
 
 ### Using the new DCS signing certificate
 
-If you are able to dual-run signing certificates in your service, you can start using the new DCS signing certificate as your secondary certificate straight away - however, you need to keep using the old certificate as your primary certificate until we rotate to the new key.
+If you are able to dual-run signing certificates in your service, you can start using the new DCS signing certificate as your secondary certificate straight away. However, you need to keep using the old certificate as your primary certificate until we rotate to the new key.
 
-DCS will start using its new signing key at the scheduled time. We’ll let you know when we have rotated to the new key. You are free to remove the old certificate at this stage.
+The DCS will start using its new signing key at the scheduled time. We’ll let you know when we have rotated to the new key. After the DCS has rotated to the new key, you are free to remove the old certificate.
 
-If you aren’t able to dual-run signing certificates, we need you to join a coordinated rotation with us on the day.
-
-This means you will need to join a conference call with us in which, simultaneously:
+If you are not able to dual-run signing certificates, we need you to join a coordinated rotation with us on the day. This means you'll need to join a conference call with us in which, simultaneously:
 
   * we deploy a release of the DCS which uses its new signing key to sign messages
   * you deploy a release of your service which uses the new DCS signing certificate
 
 ### Using the new DCS encryption certificate
 
-You can start using the new DCS integration encryption certificate straight away, as DCS can dual-run encryption keys. This means DCS can accept messages which have been encrypted using either the old or new encryption certificate.
+You can start using the new DCS integration encryption certificate straight away, as the DCS can dual-run encryption keys. This means the DCS can accept messages which have been encrypted using either the old or new encryption certificate.
 
 If you are joining us for a coordinated rotation of your signing certificate, we recommend rotating your encryption certificate at the same time.
 
-We will be removing the old encryption key shortly after switching the signing key during the scheduled call, so please make sure you are using the new encryption certificate before then.
+We'll be removing the old encryption key shortly after switching the signing key during the scheduled call, so make sure you're using the new encryption certificate before then.
 
-## Enabling dual running of DCS signing certificates
+## Enable dual running of the DCS signing certificates
 
-To avoid having to coordinate the rotation of the DCS signing certificate, we recommend that you implement dual running for this certificate in your code. Libraries that you may be using to support your connection may have builtin support for this or you may need to implement it yourself.
+To avoid having to coordinate the rotation of a DCS signing certificate, we recommend that you implement dual running for this certificate in your code. Libraries that you may be using to support your connection may have builtin support for this or you may need to implement it yourself.
 
-To implement this your code should:
-  * make it possible to configure 2 dcs signing certificates.
-  * generate a JOSE certificate thumbprints for these certificates.
-  * store the certificates in a map / dictionary with the thumbprint as the key.
-  * use the JOSE certificate thumbprint from the DCS response to select which of certificate to use.
+
+1. Make it possible to configure 2 DCS signing certificates.
+1. Generate a JOSE certificate thumbprint for these certificates using the same process as when you [Set up your JOSE certificate thumbprints](/set-up-your-JOSE-certificate-thumbprints/#set-up-your-jose-certificate-thumbprints) 
+1. Store the certificates in a map or dictionary using the JOSE thumbprint as the key.
+1. Use the JOSE certificate thumbprint from the DCS response to select which certificate to use.
 
 
 <%= partial "partials/links" %>

--- a/source/rotating-keys-and-certificates.html.md.erb
+++ b/source/rotating-keys-and-certificates.html.md.erb
@@ -1,0 +1,64 @@
+---
+title: Rotating keys and certificates
+weight: 5.6
+last_reviewed_on: 2021-2-26
+review_in: 6 months
+---
+
+# Rotating keys and certificates
+
+When the certificates containing public keys are due to expire, they must replaced with new keys and certificates. We call this process certificate rotation. There are two set of keys and certificates that must be handled, with different processes for each set.
+
+  * The keys you create and the associated certificates.
+  * The keys DCS creates and the associated certificates.
+
+## Rotating your keys and certificates
+
+When the certificates containing your public keys are due to expire, you must rotate them. If you do not, your connection to the DCS will stop working.
+
+..1. DCS will contact you to let you that your certificates need to be rotated.
+  1. Follow the process to [generate keys and request certificates](/generate-keys-and-request-certificates). You must generate new keys. Do not reuse old keys.
+..1. When you receive the new certificates, contact DCS to inform them that you ready to start using your new keys and certificates.
+  1. Wait for confirmation that DCS is ready to start using your new certificates.
+  1. When DCS has confirmed that we are ready, you can update your configuration to use the new keys and certificates.
+
+
+## Rotating DCS certificates
+
+When the certificates containing DCS's public keys are due to expire, you must rotate them. If you do not, your connection to the DCS will stop working.
+
+DCS will contact you to let you know that DCS's certificates need to be rotated. We will give you at least 1 month notice of the date when we will perform the rotation. At least 1 week before the scheduled rotation we will send you the new signing and encryption certificates. Due to the nature of how these different certificates are used, there are different procedures for when they may be updated.
+
+### Using the new DCS signing certificate
+
+If you are able to dual-run signing certificates in your service, you can start using the new DCS signing certificate as your secondary certificate straight away - however, you need to keep using the old certificate as your primary certificate until we rotate to the new key.
+
+DCS will start using its new signing key at the scheduled time. We’ll let you know when we have rotated to the new key. You are free to remove the old certificate at this stage.
+
+If you aren’t able to dual-run signing certificates, we need you to join a coordinated rotation with us on the day.
+
+This means you will need to join a conference call with us in which, simultaneously:
+
+  * we deploy a release of the DCS which uses its new signing key to sign messages
+  * you deploy a release of your service which uses the new DCS signing certificate
+
+### Using the new DCS encryption certificate
+
+You can start using the new DCS integration encryption certificate straight away, as DCS can dual-run encryption keys. This means DCS can accept messages which have been encrypted using either the old or new encryption certificate.
+
+If you are joining us for a coordinated rotation of your signing certificate, we recommend rotating your encryption certificate at the same time.
+
+We will be removing the old encryption key shortly after switching the signing key during the scheduled call, so please make sure you are using the new encryption certificate before then.
+
+## Enabling dual running of DCS signing certificates
+
+To avoid having to coordinate the rotation of the DCS signing certificate, we recommend that you implement dual running for this certificate in your code. Libraries that you may be using to support your connection may have builtin support for this or you may need to implement it yourself.
+
+To implement this your code should:
+  * make it possible to configure 2 dcs signing certificates.
+  * generate a JOSE certificate thumbprints for these certificates.
+  * store the certificates in a map / dictionary with the thumbprint as the key.
+  * use the JOSE certificate thumbprint from the DCS response to select which of certificate to use.
+
+
+<%= partial "partials/links" %>

--- a/source/rotating-keys-and-certificates.html.md.erb
+++ b/source/rotating-keys-and-certificates.html.md.erb
@@ -7,7 +7,7 @@ review_in: 6 months
 
 # Rotating keys and certificates
 
-When the certificates containing public keys are due to expire, they must replaced with new keys and certificates. We call this process certificate rotation. There are 2 sets of keys and certificates:
+When the certificates containing public keys are due to expire, they must be replaced with new keys and certificates. We call this process certificate rotation. There are 2 sets of keys and certificates:
 
   * the keys you create and the associated certificates
   * the keys the Document Checking Service (DCS) creates and the associated certificates
@@ -18,16 +18,16 @@ When the certificates containing your public keys are due to expire, you must ro
 
 1. The DCS team will contact you to let you know that you need to rotate your certificates.
 1. Follow the process to [generate keys and request certificates](/generate-keys-and-request-certificates). You must generate new keys. Do not reuse old keys.
-1. When you receive the new certificates, [contact the DCS](/support) to inform us that you are ready to start using your new keys and certificates.
+1. When you receive the new certificates, [contact the DCS](/support) to inform us that you're ready to start using your new keys and certificates.
 1. Wait for confirmation that the DCS is ready to start using your new certificates.
-1. When the DCS has confirmed we are ready, you can update your configuration to use the new keys and certificates.
+1. When the DCS team has confirmed we are ready, you can update your configuration to use the new keys and certificates.
 
 
 ## Rotating the DCS certificates
 
-When the certificates containing the DCS's public keys are due to expire, you must rotate them. If you do not, your connection to the DCS will stop working.
+When the DCS needs to rotate its certificates, the DCS team will contact you. You’ll need to use the new DCS signing certificate, and the new DCS encryption certificate. If you do not, your connection to the DCS will stop working.
 
-The DCS team will contact you to let you know that the DCS's certificates will be rotated. We'll give you at least one month's notice of the date when we will perform the rotation. 
+The DCS team will give you at least one month's notice of the date when we'll perform the rotation. 
 
 At least one week before the scheduled rotation, we'll send you the new signing and encryption certificates. There are different processes for: 
 
@@ -39,7 +39,7 @@ At least one week before the scheduled rotation, we'll send you the new signing 
 
 If you're able to dual-run signing certificates in your service, you can start using the new DCS signing certificate as your secondary certificate straight away. However, you need to keep using the old certificate as your primary certificate until we rotate to the new key.
 
-The DCS will start using its new signing key at the scheduled time. The DCS team will let you know when we have rotated to the new key. After the DCS has rotated to the new key, you are free to remove the old certificate.
+The DCS will start using its new signing key at the scheduled time. The DCS team will let you know when we have rotated to the new key. After the DCS has rotated to the new key, you can remove the old certificate.
 
 If you're not able to dual-run signing certificates, you'll need to join a coordinated rotation with us on the day. This means you'll need to join a conference call with us in which, simultaneously:
 
@@ -56,7 +56,7 @@ We'll remove the old encryption key shortly after switching the signing key duri
 
 ## Enable dual running of the DCS signing certificates
 
-To avoid having to coordinate the rotation of a DCS signing certificate, we recommend that you implement dual running for this certificate in your code. If you are not using a library with built-in support for this, you will need to implement it yourself.
+To avoid having to coordinate the rotation of a DCS signing certificate, we recommend that you implement dual running for this certificate in your code. If you're not using a library with built-in support for this, you'll need to implement it yourself.
 
 
 1. Make it possible to configure 2 DCS signing certificates.


### PR DESCRIPTION
## Why

We need documentation that explains cert rotations to DCS clients.

## What

Add documentation to help DCS clients understand certificate rotation processes.
