### PR TITLE
BAU: Remove confusing link and references to JOSE

### DIFF
--- a/source/access-the-data-in-a-DCS-response.html.md.erb
+++ b/source/access-the-data-in-a-DCS-response.html.md.erb
@@ -10,7 +10,8 @@ review_in: 6 months
 When you make a successful request to the Document Checking Service (DCS), the DCS will respond with:
 
 * a `200` HTTP response code
-* a [JOSE object](/set-up-your-JOSE-certificate-thumbprints/#set-up-your-jose-certificate-thumbprints) containing the data you requested
+* a secured JSON object with data you requested
+
 
 Follow these instructions to access the data in the DCS response. You’ll need to:
 

--- a/source/generate-certificate-thumbprints.html.md.erb
+++ b/source/generate-certificate-thumbprints.html.md.erb
@@ -1,15 +1,17 @@
 ---
-title: Set up your JOSE certificate thumbprints
+title: Generate certificate thumbprints
 weight: 4.5
 last_reviewed_on: 2020-11-11
 review_in: 6 months
 ---
 
-# Set up your JOSE certificate thumbprints
+# Generate certificate thumbprints
 
-You will need to include a certificate ‘thumbprint’ (also sometimes known as a ‘fingerprint’) in the JSON Web Signature (JWS) and JSON Web Encryption (JWE) objects you build when you sign and encrypt a Document Checking Service (DCS) payload.
+A certificate ‘thumbprint’ (also sometimes known as a ‘fingerprint’) is a unique identifier for a certificate that can be derived from the certificate itself. The DCS uses thumbprints to identify which keys and certificates are being used when handling messages.
+ 
+The thumbprint format is a Base64url encoded SHA256 hash of the certificate.
 
-The thumbprint is a hash of the public certificate used to sign or encrypt the JWS or JWE object. DCS uses the thumbprint to look up the certificate with which to validate your signature or decrypt your message.
+You will need to include a certificate thumbprint in the JSON Web Signature (JWS) and JSON Web Encryption (JWE) objects you build when you [sign and encrypt a Document Checking Service (DCS) payload](/sign-and-encrypt-a-DCS-payload/#sign-and-encrypt-a-dcs-payload). You may also want to generate thumbprints for DCS signing certificates if you [enable dual running of the DCS signing certificates](/rotating-keys-and-certificates/#enable-dual-running-of-the-dcs-signing-certificates).
 
 The [library you use to build JWS and JWE objects](/sign-and-encrypt-a-DCS-payload/#choose-a-library-to-use-for-jws-and-jwe) may be able to create thumbprints for you.
 
@@ -17,7 +19,7 @@ If you need to create the thumbprints manually yourself, you will need to:
 
 1. Check your certificate is in binary DER format.
 1. Hash the binary representation of the certificate.
-1. Use the thumbprint to build a JWS or JWE object.
+1. Base64url encode the hash.
 
 ## Check your certificate is in binary DER format
 
@@ -68,9 +70,12 @@ Use a library or a command line tool to hash the certificate.
 
 You need to generate the SHA256 hash of your certificate’s binary DER.
 
-You need to:
+You need to make sure the hash is in raw bytes - some tools return a Base64 string or hex string by default.
 
-1. Make sure the hash is in raw bytes - some tools return a Base64 string or hex string by default.
+## Base64url encode the hash
+
+Use a library or command line tool to Base64url encode the hash.
+
 1. Encode the bytes into Base64url.
 1. Remove padding by stripping any `=` characters.
 
@@ -81,8 +86,5 @@ If your library or command line tool cannot encode bytes to Base64url directly, 
 1. Encode the bytes to Base64.
 1. Convert the Base64 string to Base64url in your own code.
 
-## Use the thumbprint to build a JWS or JWE object
-
-Once you’ve created your SHA256 hash, you can use it when you [sign and encrypt your DCS payload](/sign-and-encrypt-a-DCS-payload/#sign-and-encrypt-a-dcs-payload).
 
 <%= partial "partials/links" %>

--- a/source/integrating-with-the-dcs.html.md.erb
+++ b/source/integrating-with-the-dcs.html.md.erb
@@ -27,7 +27,7 @@ To build a working DCS client, you'll need to:
 1. [Enrol with the DCS certificate authority](https://dcs-pilot-docs.cloudapps.digital/enrol-with-the-DCS-certificate-authority/#enrol-with-the-dcs-certificate-authority).
 1. [Generate keys and request certificates](/generate-keys-and-request-certificates/#generate-keys-and-request-certificates) - you’ll need to [contact DCS support](/support/#support) to get the Public Key Infrastructure (PKI) information so you can get started with integrating with the DCS.
 1. [Create a network connection to the DCS](/create-a-network-connection/#create-a-network-connection-to-the-dcs) using mutual authentication.
-1. [Set up your JOSE certificate thumbprints](/set-up-your-JOSE-certificate-thumbprints/#set-up-your-jose-certificate-thumbprints).
+1. [Generate certificate thumbprints](/generate-certificate-thumbprints/#generate-certificate-thumbprints).
 1. [Sign and encrypt a DCS payload](/sign-and-encrypt-a-DCS-payload/#sign-and-encrypt-a-dcs-payload).
 1. [Access the data in a DCS response](/access-the-data-in-a-DCS-response/#access-the-data-in-a-dcs-response).
 

--- a/source/rotating-keys-and-certificates.html.md.erb
+++ b/source/rotating-keys-and-certificates.html.md.erb
@@ -60,9 +60,9 @@ To avoid having to coordinate the rotation of a DCS signing certificate, we reco
 
 
 1. Make it possible to configure 2 DCS signing certificates.
-1. Generate a JOSE certificate thumbprint for these certificates using the same process as when you [set up your JOSE certificate thumbprints](/set-up-your-JOSE-certificate-thumbprints/#set-up-your-jose-certificate-thumbprints) 
-1. Store the certificates in a map or dictionary using the JOSE thumbprint as the key.
-1. Use the JOSE certificate thumbprint from the DCS response to select which certificate to use.
+1. [Generate certificate thumbprints](/generate-certificate-thumbprints) for these certificates.
+1. Store the certificates in a map or dictionary using the thumbprint as the key.
+1. Use the certificate thumbprint from the DCS response to select which certificate to use.
 
 
 <%= partial "partials/links" %>

--- a/source/sign-and-encrypt-a-DCS-payload.html.md.erb
+++ b/source/sign-and-encrypt-a-DCS-payload.html.md.erb
@@ -71,7 +71,7 @@ For the DCS, you need to set the following headers:
 1. `x5t#S256` contains the SHA256 thumbprint of your certificate.
 1. `alg` must be set to one of: `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, or `PS512`.
 
-You must set the `x5t#S256` header. To set it, you’ll need to have [generated a thumbprint for your signing certificate](/set-up-your-JOSE-certificate-thumbprints).
+You must set the `x5t#S256` header. To set it, you’ll need to [generate a thumbprint](/generate-certificate-thumbprints) for your signing certificate.
 
 Depending on the library you use, you might have to manually construct the JWS header. Your header should look like this:
 
@@ -101,7 +101,7 @@ You must set the following headers:
 * `typ` must be set to `JWE`
 * `x5t#S256` contains the SHA256 thumbprint of the DCS encryption certificate
 
-You must set the `x5t#S256` header. To set it, you’ll need to have [generated a thumbprint for the DCS encryption certificate](/set-up-your-JOSE-certificate-thumbprints).
+You must set the `x5t#S256` header. To set it, you’ll need to [generate a thumbprint](/generate-certificate-thumbprints) for the DCS encryption certificate.
 
 Your header should look like this:
 
@@ -113,15 +113,6 @@ Your header should look like this:
   "x5t#S256":"PJLEl_B6MFKaMEG6HK7BBdaueJc7e-SiimQfvEpTYj4"
 }
 ```
-
-### Using encryption algorithms
-
-The encrypted component of the JSON Object Signing and Encryption (JOSE) message must use:
-
-* `RSA-OAEP-256` as the algorithm
-* any encryption method [permitted by RFC 7518][supported-JWE-encodings], for example `A128CBC-HS256`
-
-You can [learn more about these in the JSON Web Algorithms specification][RFC 7518].
 
 ## Sign your JWE object to complete the process
 


### PR DESCRIPTION
## Why

The document contains a link labeled "a JOSE object" that points to documentation about how to create a certificate thumbprint. This is confusing. We should change it.

## What

We do not have a document the simply explains what a JOSE object is, furthermore we rarely mention JOSE and can avoid doing so.  So we will remove all references to JOSE in our text. Technical uses in `Content-Type` and names of libraries remain, without comment.

## Technical writer support

Does this all make sense?