### PR TITLE
BAU: Remove reference to integration

### DIFF
--- a/source/rotating-keys-and-certificates.html.md.erb
+++ b/source/rotating-keys-and-certificates.html.md.erb
@@ -48,7 +48,7 @@ If you're not able to dual-run signing certificates, you'll need to join a coord
 
 ### Using the new DCS encryption certificate
 
-You can start using the new DCS integration encryption certificate straight away, as the DCS can dual-run encryption keys. This means the DCS can accept messages which have been encrypted using either the old or new encryption certificate.
+You can start using the new DCS encryption certificate straight away, as the DCS can dual-run encryption keys. This means the DCS can accept messages which have been encrypted using either the old or new encryption certificate.
 
 If you're joining us for a coordinated rotation of your signing certificate, we recommend rotating your encryption certificate at the same time.
 


### PR DESCRIPTION
## Why

The document mistakenly specifies using an "integration encryption certificate" when the environment is not relevant.

## What

Remove reference to `integration`.
